### PR TITLE
[PIO-12] Add Scala style rules, FileTabChecker, NonASCIICharacterChecker and SpaceAfterCommentStartChecker

### DIFF
--- a/data/src/main/scala/org/apache/predictionio/data/api/EventServer.scala
+++ b/data/src/main/scala/org/apache/predictionio/data/api/EventServer.scala
@@ -110,17 +110,17 @@ class  EventServiceActor(
           }.getOrElse(FailedAuth)
         }.getOrElse {
           // with accessKey in header, return appId if succeed
-          ctx.request.headers.find(_.name == "Authorization").map { authHeader ⇒
+          ctx.request.headers.find(_.name == "Authorization").map { authHeader =>
             authHeader.value.split("Basic ") match {
-              case Array(_, value) ⇒
+              case Array(_, value) =>
                 val appAccessKey =
                   new String(base64Decoder.decodeBuffer(value)).trim.split(":")(0)
                 accessKeysClient.get(appAccessKey) match {
-                  case Some(k) ⇒ Right(AuthData(k.appid, None, k.events))
-                  case None ⇒ FailedAuth
+                  case Some(k) => Right(AuthData(k.appid, None, k.events))
+                  case None => FailedAuth
                 }
 
-              case _ ⇒ FailedAuth
+              case _ => FailedAuth
             }
           }.getOrElse(MissedAuth)
         }

--- a/data/src/main/scala/org/apache/predictionio/data/webhooks/segmentio/SegmentIOConnector.scala
+++ b/data/src/main/scala/org/apache/predictionio/data/webhooks/segmentio/SegmentIOConnector.scala
@@ -35,57 +35,57 @@ private[predictionio] object SegmentIOConnector extends JsonConnector {
         )
       }
 */
-    } catch { case _: Throwable ⇒
+    } catch { case _: Throwable =>
       throw new ConnectorException(s"Failed to get segment.io API version.")
     }
 
     val common = try {
       data.extract[Common]
     } catch {
-      case e: Throwable ⇒ throw new ConnectorException(
+      case e: Throwable => throw new ConnectorException(
         s"Cannot extract Common field from $data. ${e.getMessage}", e
       )
     }
 
     try {
       common.`type` match {
-        case "identify" ⇒
+        case "identify" =>
           toEventJson(
             common = common,
             identify = data.extract[Events.Identify]
           )
 
-        case "track" ⇒
+        case "track" =>
           toEventJson(
             common = common,
             track = data.extract[Events.Track]
           )
 
-        case "alias" ⇒
+        case "alias" =>
           toEventJson(
             common = common,
             alias = data.extract[Events.Alias]
           )
 
-        case "page" ⇒
+        case "page" =>
           toEventJson(
             common = common,
             page = data.extract[Events.Page]
           )
 
-        case "screen" ⇒
+        case "screen" =>
           toEventJson(
             common = common,
             screen = data.extract[Events.Screen]
           )
 
-        case "group" ⇒
+        case "group" =>
           toEventJson(
             common = common,
             group = data.extract[Events.Group]
           )
 
-        case _ ⇒
+        case _ =>
           throw new ConnectorException(
             s"Cannot convert unknown type ${common.`type`} to event JSON."
           )
@@ -101,59 +101,59 @@ private[predictionio] object SegmentIOConnector extends JsonConnector {
 
   def toEventJson(common: Common, identify: Events.Identify ): JObject = {
     import org.json4s.JsonDSL._
-    val eventProperties = "traits" → identify.traits
+    val eventProperties = "traits" -> identify.traits
     toJson(common, eventProperties)
   }
 
   def toEventJson(common: Common, track: Events.Track): JObject = {
     import org.json4s.JsonDSL._
     val eventProperties =
-      ("properties" → track.properties) ~
-      ("event" → track.event)
+      ("properties" -> track.properties) ~
+      ("event" -> track.event)
     toJson(common, eventProperties)
   }
 
   def toEventJson(common: Common, alias: Events.Alias): JObject = {
     import org.json4s.JsonDSL._
-    toJson(common, "previous_id" → alias.previous_id)
+    toJson(common, "previous_id" -> alias.previous_id)
   }
 
   def toEventJson(common: Common, screen: Events.Screen): JObject = {
     import org.json4s.JsonDSL._
     val eventProperties =
-      ("name" → screen.name) ~
-      ("properties" → screen.properties)
+      ("name" -> screen.name) ~
+      ("properties" -> screen.properties)
     toJson(common, eventProperties)
   }
 
   def toEventJson(common: Common, page: Events.Page): JObject = {
     import org.json4s.JsonDSL._
     val eventProperties =
-      ("name" → page.name) ~
-      ("properties" → page.properties)
+      ("name" -> page.name) ~
+      ("properties" -> page.properties)
     toJson(common, eventProperties)
   }
 
   def toEventJson(common: Common, group: Events.Group): JObject = {
     import org.json4s.JsonDSL._
     val eventProperties =
-      ("group_id" → group.group_id) ~
-      ("traits" → group.traits)
+      ("group_id" -> group.group_id) ~
+      ("traits" -> group.traits)
     toJson(common, eventProperties)
   }
 
   private def toJson(common: Common, props: JObject): JsonAST.JObject = {
     val commonFields = commonToJson(common)
-    JObject(("properties" → properties(common, props)) :: commonFields.obj)
+    JObject(("properties" -> properties(common, props)) :: commonFields.obj)
   }
 
   private def properties(common: Common, eventProps: JObject): JObject = {
     import org.json4s.JsonDSL._
-    common.context map { context ⇒
+    common.context map { context =>
       try {
-        ("context" → Extraction.decompose(context)) ~ eventProps
+        ("context" -> Extraction.decompose(context)) ~ eventProps
       } catch {
-        case e: Throwable ⇒
+        case e: Throwable =>
           throw new ConnectorException(
             s"Cannot convert $context to event JSON. ${e.getMessage }", e
           )
@@ -167,13 +167,13 @@ private[predictionio] object SegmentIOConnector extends JsonConnector {
   private def commonToJson(common: Common, typ: String): JObject = {
     import org.json4s.JsonDSL._
       common.user_id.orElse(common.anonymous_id) match {
-        case Some(userId) ⇒
-          ("event" → typ) ~
-            ("entityType" → "user") ~
-            ("entityId" → userId) ~
-            ("eventTime" → common.timestamp)
+        case Some(userId) =>
+          ("event" -> typ) ~
+            ("entityType" -> "user") ~
+            ("entityId" -> userId) ~
+            ("eventTime" -> common.timestamp)
 
-        case None ⇒
+        case None =>
           throw new ConnectorException(
             "there was no `userId` or `anonymousId` in the common fields."
           )

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -98,4 +98,13 @@ limitations under the License.
     <check level="error"
            class="org.scalastyle.file.WhitespaceEndOfLineChecker"
            enabled="true"/>
+    <check level="error"
+           class="org.scalastyle.file.FileTabChecker"
+           enabled="true"/>
+    <check level="error"
+           class="org.scalastyle.scalariform.NonASCIICharacterChecker"
+           enabled="true"/>
+    <check level="error"
+           class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker"
+           enabled="true"/>
 </scalastyle>


### PR DESCRIPTION
As described in [PIO-12](https://issues.apache.org/jira/browse/PIO-12), it seems there are some basic rules missing. This PR adds the rules below:

- `FileTabChecker`
  This complies http://docs.scala-lang.org/style/indentation

- `NonASCIICharacterChecker`
  Currently, there are some weird non-ascii characters such as, `⇒` instead of `=>` and `→` instead of `->`. 

- `SpaceAfterCommentStartChecker`
  Please refer [this](http://www.scalastyle.org/rules-dev.html#org_scalastyle_scalariform_SpaceAfterCommentStartChecker). Both comply [Java doc style](http://www.oracle.com/technetwork/articles/java/index-137868.html) and [Scala doc style](http://docs.scala-lang.org/style/scaladoc.html).

