### PR TITLE
[MINOR] Replace the deprecated usage of Spark API

### DIFF
--- a/docs/manual/source/install/index.html.md.erb
+++ b/docs/manual/source/install/index.html.md.erb
@@ -27,7 +27,7 @@ It is **very important** to meet the minimum version of the following
 technologies that power PredictionIO.
 
 * Apache Hadoop 2.4.0 (optional, required only if YARN and HDFS are needed)
-* Apache Spark 1.3.0 for Hadoop 2.4
+* Apache Spark 1.4.0 for Hadoop 2.4
 * Java SE Development Kit 7
 
 and one of the following sets:

--- a/tools/src/main/scala/org/apache/predictionio/tools/export/EventsToFile.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/export/EventsToFile.scala
@@ -23,6 +23,7 @@ import org.apache.predictionio.workflow.WorkflowContext
 import org.apache.predictionio.workflow.WorkflowUtils
 
 import grizzled.slf4j.Logging
+import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.SQLContext
 import org.json4s.native.Serialization._
 
@@ -94,8 +95,8 @@ object EventsToFile extends Logging {
       if (args.format == "json") {
         jsonStringRdd.saveAsTextFile(args.outputPath)
       } else {
-        val jsonRdd = sqlContext.jsonRDD(jsonStringRdd)
-        jsonRdd.saveAsParquetFile(args.outputPath)
+        val jsonDf = sqlContext.read.json(jsonStringRdd)
+        jsonDf.write.mode(SaveMode.ErrorIfExists).parquet(args.outputPath)
       }
       info(s"Events are exported to ${args.outputPath}/.")
       info("Done.")


### PR DESCRIPTION
This PR simply replaces the deprecated usage of Spark API in 1.4.0.

So, this PR replaces,

- `parquetFile` to `read.parquet` (See [here](https://github.com/apache/spark/blob/branch-1.4/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala#L1099))

```
- sqlContext.parquetFile(fileName)
+ sqlContext.read.parquet(fileName)
```

- `saveAsParquetFile` to  `write.mode(SaveMode.ErrorIfExists).parquet` (See [here]( https://github.com/apache/spark/blob/branch-1.4/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala#L1503-L1508))

```
- df.saveAsParquetFile(fileName)
+ df.write.mode(SaveMode.ErrorIfExists).parquet(fileName)
```

- `jsonRDD` to `read.json` (See [here](https://github.com/apache/spark/blob/branch-1.4/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala#L1145-L1148))

```
- val jsonRdd = sqlContext.jsonRDD(jsonStringRdd)
+ val jsonDf = sqlContext.read.json(jsonStringRdd)
```
