### PR TITLE
[PIO-5] Replace all *.prediction.io urls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,11 @@
-Thank you for contributing to PredictionIO. Please read and sign the
-[Contributor Agreement](http://prediction.io/cla). We cannot merge your PR
-without the agreement.
+Thank you for your interest in contributing to Apache PredictionIO (incubating).
+Our mission is to enable developers to build scalable machine learning applications easily.
+Here is how you can help with the project development. If you have any
+question regarding development at anytime, please free to subscribe and post to
+the Development Mailing List <mailto:dev-subscribe@predictionio.incubator.apache.org>.
 
 For code contribution, please follow guidelines at
-http://docs.prediction.io/community/contribute-code/.
+http://predictionio.incubator.apache.org/community/contribute-code/.
 
 For documentation contribution, please follow guidelines at
-http://docs.prediction.io/community/contribute-documentation/. Notice that since
-the documentation is inside the main code tree, signing the CLA is required
-before we can merge your PR.
-
-If you have questions about these terms please contact us at
-support@prediction.io.
+http://predictionio.incubator.apache.org/community/contribute-documentation/.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [PredictionIO](http://prediction.io)
+# [PredictionIO](http://predictionio.incubator.apache.org)
 
 [![Build
 Status](https://api.travis-ci.org/apache/incubator-predictionio.svg?branch=develop)](https://travis-ci.org/apache/incubator-predictionio)
@@ -7,7 +7,7 @@ PredictionIO is an open source machine learning framework for developers and
 data scientists. It supports event collection, deployment of algorithms,
 evaluation, querying predictive results via REST APIs.
 
-To get started, check out http://prediction.io!
+To get started, check out http://predictionio.incubator.apache.org!
 
 
 ## Table of contents
@@ -24,50 +24,45 @@ To get started, check out http://prediction.io!
 Five installation options available.
 
 *   [Installing PredictionIO on Linux / Mac OS
-    X](http://docs.prediction.io/install/install-linux/)
+    X](http://predictionio.incubator.apache.org/install/install-linux/)
 *   [Installing PredictionIO from Source
-    Code](http://docs.prediction.io/install/install-sourcecode/)
+    Code](http://predictionio.incubator.apache.org/install/install-sourcecode/)
     If you are installing from source code, it's recommended that you clone the
     master branch.
 *   [Launching PredictionIO on
-    AWS](http://docs.prediction.io/install/launch-aws/)
+    AWS](http://predictionio.incubator.apache.org/install/launch-aws/)
 *   [Installing PredictionIO with
     Docker](https://github.com/mingfang/docker-predictionio) (Community
     contributed)
 *   [Installing PredictionIO with
-    Vagrant](http://docs.prediction.io/install/install-vagrant/)
+    Vagrant](http://predictionio.incubator.apache.org/install/install-vagrant/)
 
 
 ## Quick Start
 
 *   [Recommendation Engine Template Quick
-    Start](http://docs.prediction.io/templates/recommendation/quickstart/)
+    Start](http://predictionio.incubator.apache.org/templates/recommendation/quickstart/)
     Guide
 *   [Similiar Product Engine Template Quick
-    Start](http://docs.prediction.io/templates/similarproduct/quickstart/)
+    Start](http://predictionio.incubator.apache.org/templates/similarproduct/quickstart/)
     Guide
 *   [Classification Engine Template Quick
-    Start](http://docs.prediction.io/templates/classification/quickstart/)
+    Start](http://predictionio.incubator.apache.org/templates/classification/quickstart/)
     Guide
 
 
 ## Bugs and Feature Requests
 
-Have a bug or a feature request?  Please search for existing and closed issues
-on the [Community
-Forum](https://groups.google.com/forum/#!forum/predictionio-user). If your
-problem or idea is not addressed yet, [please open a new
-issue](https://github.com/PredictionIO/PredictionIO/issues/new).
-
+Use [Apache JIRA](https://issues.apache.org/jira/browse/PIO) to report bugs or request new features.
 
 ## Documentation
 
 PredictionIO's documentation, included in this repo in the `docs/manual`
 directory, is built with [Middleman](http://middlemanapp.com/) and publicly
-hosted at [docs.prediction.io](http://docs.prediction.io/).
+hosted at [predictionio.incubator.apache.org](http://predictionio.incubator.apache.org/).
 
 Interested in helping with our documentation? Read [Contributing
-Documentation](http://docs.prediction.io/community/contribute-documentation/).
+Documentation](http://predictionio.incubator.apache.org/community/contribute-documentation/).
 
 [![Dependency
 Status](https://gemnasium.com/PredictionIO/PredictionIO.svg)](https://gemnasium.com/PredictionIO/PredictionIO)
@@ -77,21 +72,17 @@ Status](https://gemnasium.com/PredictionIO/PredictionIO.svg)](https://gemnasium.
 
 Keep track of development and community news.
 
+*   Subscribe to the user mailing list <mailto:user-subscribe@predictionio.incubator.apache.org>
+    and the dev mailing list <mailto:dev-subscribe@predictionio.incubator.apache.org>
 *   Follow [@predictionio](https://twitter.com/predictionio) on Twitter.
-*   Read and subscribe to [the
-    Newsletter](https://prediction.io/#newsletter).
-*   Join the [Community
-    Forum](https://groups.google.com/forum/#!forum/predictionio-user).
 
 
 ## Contributing
 
-Please read and sign the [Contributor Agreement](http://prediction.io/cla). If
-you have any questions, you can post on the [Contributor
-Forum](https://groups.google.com/forum/#!forum/predictionio-dev).
+Read the [Contribute Code](http://predictionio.incubator.apache.org/community/contribute-code/) page.
 
 You can also list your projects on the [Community Project
-page](http://docs.prediction.io/community/projects/).
+page](http://predictionio.incubator.apache.org//community/projects/).
 
 
 ## License

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 ##Release Notes and News
 
-**Note:** For upgrade instructions please refer to [this page](/resources/upgrade/).
+**Note:** For upgrade instructions please refer to [this page](http://predictionio.incubator.apache.org/resources/upgrade/).
 
 ###v0.9.6
 

--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,7 @@ pioUnidoc := {
 }
 
 pomExtra in ThisBuild := {
-  <url>https://prediction.io</url>
+  <url>http://predictionio.incubator.apache.org</url>
   <licenses>
     <license>
       <name>Apache 2</name>
@@ -167,15 +167,15 @@ pomExtra in ThisBuild := {
     </license>
   </licenses>
   <scm>
-    <connection>scm:git:github.com/PredictionIO/PredictionIO</connection>
-    <developerConnection>scm:git:git@github.com:PredictionIO/PredictionIO.git</developerConnection>
-    <url>github.com/PredictionIO/PredictionIO</url>
+    <connection>scm:git:github.com/apache/incubator-predictionio</connection>
+    <developerConnection>scm:git:git@github.com:apache/incubator-predictionio.git</developerConnection>
+    <url>github.com/apache/incubator-predictionio</url>
   </scm>
   <developers>
     <developer>
       <id>pio</id>
       <name>The PredictionIO Team</name>
-      <url>https://prediction.io</url>
+      <url>http://predictionio.incubator.apache.org</url>
     </developer>
   </developers>
 }

--- a/conf/pio-env.sh.template
+++ b/conf/pio-env.sh.template
@@ -36,7 +36,7 @@ PIO_FS_TMPDIR=$PIO_FS_BASEDIR/tmp
 # storage facilities. Default values are shown below.
 #
 # For more information on storage configuration please refer to
-# https://docs.prediction.io/system/anotherdatastore/
+# http://predictionio.incubator.apache.org/system/anotherdatastore/
 
 # Storage Repositories
 

--- a/core/src/main/scala/org/apache/predictionio/controller/package.scala
+++ b/core/src/main/scala/org/apache/predictionio/controller/package.scala
@@ -23,7 +23,7 @@ package org.apache.predictionio
   *
   * == The DASE Paradigm ==
   * The building blocks together form the DASE paradigm. Learn more about DASE
-  * [[http://docs.prediction.io/customize/ here]].
+  * [[http://predictionio.incubator.apache.org/customize/ here]].
   *
   * == Types of Building Blocks ==
   * Depending on the problem you are solving, you would need to pick appropriate

--- a/core/src/main/scala/org/apache/predictionio/workflow/WorkflowUtils.scala
+++ b/core/src/main/scala/org/apache/predictionio/workflow/WorkflowUtils.scala
@@ -286,7 +286,7 @@ object WorkflowUtils extends Logging {
         "Since 0.8.4, the 'params' field is required in engine.json" +
         " in order to specify parameters for DataSource, Preparator or" +
         " Serving.\n" +
-        "Please go to https://docs.prediction.io/resources/upgrade/" +
+        "Please go to http://predictionio.incubator.apache.org/resources/upgrade/" +
         " for detailed instruction of how to change engine.json.")
       sys.exit(1)
     }

--- a/data/README.md
+++ b/data/README.md
@@ -1,6 +1,6 @@
 ## Data Collection API
 
-Please refer to the documentation site - [Collecting Data through Event API](http://docs.prediction.io/datacollection/eventapi/).
+Please refer to the documentation site - [Collecting Data through REST/SDKs](http://predictionio.incubator.apache.org/datacollection/eventapi/).
 
 ## For Development Use only:
 

--- a/examples/experimental/scala-parallel-recommendation-cat/README.md
+++ b/examples/experimental/scala-parallel-recommendation-cat/README.md
@@ -3,7 +3,7 @@
 ## Documentation
 
 The data requirement is similar to "Similar Product Template". Please see.
-http://docs.prediction.io/templates/similarproduct/quickstart/
+http://predictionio.incubator.apache.org/templates/similarproduct/quickstart/
 
 By default, view events and MLlib ALS trainImplicit is used.
 

--- a/examples/scala-parallel-classification/custom-attributes/README.md
+++ b/examples/scala-parallel-classification/custom-attributes/README.md
@@ -4,7 +4,7 @@ This example engine is based on Classification Tempplate version v0.1.1 and is m
 
 ## Classification template
 
-Please refer to http://docs.prediction.io/templates/classification/quickstart/
+Please refer to http://predictionio.incubator.apache.org/templates/classification/quickstart/
 
 ## Development Notes
 

--- a/examples/scala-parallel-ecommercerecommendation/train-with-rate-event/README.md
+++ b/examples/scala-parallel-ecommercerecommendation/train-with-rate-event/README.md
@@ -12,9 +12,9 @@ You can find the complete modified source code in `src/` directory.
 
 ## Documentation
 
-Please refer to http://docs.prediction.io/templates/ecommercerecommendation/quickstart/
+Please refer to http://predictionio.incubator.apache.org/templates/ecommercerecommendation/quickstart/
 and
-http://docs.prediction.io/templates/ecommercerecommendation/train-with-rate-event/
+http://predictionio.incubator.apache.org/templates/ecommercerecommendation/train-with-rate-event/
 
 ### import sample data
 

--- a/examples/scala-parallel-ecommercerecommendation/weighted-items/README.md
+++ b/examples/scala-parallel-ecommercerecommendation/weighted-items/README.md
@@ -10,7 +10,7 @@ values smaller than 0.0 are invalid.
 
 ## Documentation
 
-Please refer to http://docs.prediction.io/templates/ecommercerecommendation/quickstart/
+Please refer to http://predictionio.incubator.apache.org/templates/ecommercerecommendation/quickstart/
 
 ## Development Notes
 

--- a/examples/scala-parallel-recommendation/filter-by-category/README.md
+++ b/examples/scala-parallel-recommendation/filter-by-category/README.md
@@ -5,7 +5,7 @@ of categories, queries include a `categories` field and results only include ite
 
 ## Documentation
 
-Please refer to http://docs.prediction.io/templates/recommendation/quickstart/
+Please refer to http://predictionio.incubator.apache.org/templates/recommendation/quickstart/
 
 ## Development Notes
 

--- a/examples/scala-parallel-similarproduct/add-and-return-item-properties/README.md
+++ b/examples/scala-parallel-similarproduct/add-and-return-item-properties/README.md
@@ -3,16 +3,16 @@
 ---
 
 This small how-to explains how to add user defined properties to items returned by PredictionIO engine.
-This how-to is based on the [Similar Product Engine Template](http://docs.prediction.io/templates/similarproduct/quickstart/) version v0.1.3
+This how-to is based on the [Similar Product Engine Template](http://predictionio.incubator.apache.org/templates/similarproduct/quickstart/) version v0.1.3
 To use this how-to you need to be familiar with scala programming language.
-In this how-to we also suppose you was able to set up and run `Similar Product Engine` (see their [quick start guide](http://docs.prediction.io/templates/similarproduct/quickstart/)).
+In this how-to we also suppose you was able to set up and run `Similar Product Engine` (see their [quick start guide](http://predictionio.incubator.apache.org/templates/similarproduct/quickstart/)).
 
 A full end-to-end example can be found on
 [GitHub](https://github.com/PredictionIO/PredictionIO/tree/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties).
 
 ## THE TASK
 
-Suppose you would like to use [Similar Product Engine](http://docs.prediction.io/templates/similarproduct/quickstart/)
+Suppose you would like to use [Similar Product Engine](http://predictionio.incubator.apache.org/templates/similarproduct/quickstart/)
 for suggesting your users the videos they can also like. The `Similar Product Engine` will answer to you
 with list of IDs for such videos. So, for example `REST` response from the engine right now
 looks like the one below
@@ -53,7 +53,7 @@ for your case should look similar to the posted below
 
 ### The Main Idea
 
-Recall [the DASE Architecture](http://docs.prediction.io/templates/similarproduct/dase/), a PredictionIO engine has
+Recall [the DASE Architecture](http://predictionio.incubator.apache.org/templates/similarproduct/dase/), a PredictionIO engine has
 4 main components: `Data Source`, `Data Preparator`, `Algorithm`, and `Serving`
 components. To achieve your goal, you will need provide the information about video to engine
 (using sdk), and then let this information to pass from `Data Source` through all the engine

--- a/examples/scala-parallel-similarproduct/add-rateevent/README.md
+++ b/examples/scala-parallel-similarproduct/add-rateevent/README.md
@@ -6,7 +6,7 @@ For example, An User would rate an item with a score or rating.The rating is use
 
 ## Documentation
 
-Please refer to http://docs.prediction.io/templates/similarproduct/quickstart/
+Please refer to http://predictionio.incubator.apache.org/templates/similarproduct/quickstart/
 
 
 

--- a/examples/scala-parallel-similarproduct/filterbyyear/README.md
+++ b/examples/scala-parallel-similarproduct/filterbyyear/README.md
@@ -6,7 +6,7 @@ For example, recommend movies after year 1990.
 
 ## Documentation
 
-Please refer to http://docs.prediction.io/templates/similarproduct/quickstart/
+Please refer to http://predictionio.incubator.apache.org/templates/similarproduct/quickstart/
 
 ## Development Notes
 

--- a/examples/scala-parallel-similarproduct/multi/README.md
+++ b/examples/scala-parallel-similarproduct/multi/README.md
@@ -1,4 +1,4 @@
 
 This is based on Similar Product Template v0.1.0
 
-Please refer to http://docs.prediction.io/templates/similarproduct/multi-events-multi-algos/
+Please refer to http://predictionio.incubator.apache.org/templates/similarproduct/multi-events-multi-algos/

--- a/examples/scala-parallel-similarproduct/no-set-user/README.md
+++ b/examples/scala-parallel-similarproduct/no-set-user/README.md
@@ -6,7 +6,7 @@ This example engine is based on Similar Product Template version v0.1.3.
 
 ## Documentation
 
-Please refer to http://docs.prediction.io/templates/similarproduct/quickstart/
+Please refer to http://predictionio.incubator.apache.org/templates/similarproduct/quickstart/
 
 ## Development Notes
 

--- a/examples/scala-parallel-similarproduct/recommended-user/README.md
+++ b/examples/scala-parallel-similarproduct/recommended-user/README.md
@@ -142,7 +142,7 @@ Likewise, if a black-list is provided, the engine will exclude those users in it
 
 ## Documentation
 
-May refer to http://docs.prediction.io/templates/similarproduct/quickstart/ with difference mentioned above.
+May refer to http://predictionio.incubator.apache.org/templates/similarproduct/quickstart/ with difference mentioned above.
 
 ## Development Notes
 


### PR DESCRIPTION
Update URLs in current develop codebase.

- CONTRIBUTING.md Updates the file since it has been out-of-date. No agreement should be signed anymore.

- README.md Creates a new JIRA [PIO-13](https://issues.apache.org/jira/browse/PIO-13) for updating the document dependency check.

- RELEASE.md Some of the links here are missing and have no replacement.

- URLs in docs are ignored in this PR. I believe URLs in docs will be fixed in [PIO-6](https://issues.apache.org/jira/browse/PIO-6).

- tools/src/main/scala/org/apache/predictionio/tools/console/Template.scala Some of the URLs in this file are broken and have no replacement.

- bin/install.sh This file should be fixed in [PIO-10](https://issues.apache.org/jira/browse/PIO-10).
 