### PR TITLE
Set correct Github URL for downloading releases

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -290,7 +290,7 @@ echo -e "\033[1;36mStarting PredictionIO setup in:\033[0m $pio_dir"
 cd ${TEMP_DIR}
 if [[ ! -e ${PIO_FILE} ]]; then
   echo "Downloading PredictionIO..."
-  curl -OL https://github.com/PredictionIO/PredictionIO/releases/download/v${PIO_VERSION}/${PIO_FILE}
+  curl -OL https://github.com/apache/incubator-predictionio/releases/download/v${PIO_VERSION}/${PIO_FILE}
 fi
 tar zxf ${PIO_FILE}
 rm -rf ${pio_dir}


### PR DESCRIPTION
This will get us closer to solving #251 

The second part to solving this issue will involve restoring the release tags that have been lost since the project was moved.

Because version `0.9.6` is specified in the install script, only that tag is really needed for now. Once the tag has been pushed, Github should create a release and the file needed to make the install script work will be generated.

Would someone with appropriate permissions be able push the tag?