### PR TITLE
[PIO-16] Fix Github links correctly across documentation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@
 
 ###v0.9.6
 
-November, 2015 | [Release Notes](https://github.com/apache/incubator-predictionio/blob/develop/RELEASE.md) have been moved to Github and you are reading them. For a detailed list of commits check [this page](https://github.com/apache/incubator-predictionio/commits/develop)
+November, 2015 | [Release Notes](https://github.com/apache/incubator-predictionio/blob/master/RELEASE.md) have been moved to Github and you are reading them. For a detailed list of commits check [this page](https://github.com/apache/incubator-predictionio/commits/master)
 
 - Upgrade components for install/runtime to Hbase 1, Spark 1.5.2 PIO still runs on older HBase and Spark back to 1.3.1, upgrading install of Elaticsearch to 1.5.2 since pio run well on it but also runs on older versions.
 - Support for maintaining a moving window of events by discarding old events from the EventStore
@@ -12,7 +12,7 @@ November, 2015 | [Release Notes](https://github.com/apache/incubator-predictioni
 
 ###v0.9.5 
 
-October 14th, 2015 | [Release Notes](https://github.com/apache/incubator-predictionio/blob/develop/RELEASE.md) have been moved to Github and you are reading them. For a detailed list of commits check [this page](https://github.com/apache/incubator-predictionio/commits/v0.9.5)
+October 14th, 2015 | [Release Notes](https://github.com/apache/incubator-predictionio/blob/master/RELEASE.md) have been moved to Github and you are reading them. For a detailed list of commits check [this page](https://github.com/apache/incubator-predictionio/commits/v0.9.5)
 
 - Support batches of events sent to the EventServer as json arrays
 - Support creating an Elasticsearch StorageClient created for an Elasticsearch cluster from variables in pio-env.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@
 
 ###v0.9.6
 
-November, 2015 | [Release Notes](https://github.com/PredictionIO/PredictionIO/blob/master/RELEASE.md) have been moved to Github and you are reading them. For a detailed list of commits check [this page](https://github.com/PredictionIO/PredictionIO/commits/master)
+November, 2015 | [Release Notes](https://github.com/apache/incubator-predictionio/blob/develop/RELEASE.md) have been moved to Github and you are reading them. For a detailed list of commits check [this page](https://github.com/apache/incubator-predictionio/commits/develop)
 
 - Upgrade components for install/runtime to Hbase 1, Spark 1.5.2 PIO still runs on older HBase and Spark back to 1.3.1, upgrading install of Elaticsearch to 1.5.2 since pio run well on it but also runs on older versions.
 - Support for maintaining a moving window of events by discarding old events from the EventStore
@@ -12,7 +12,7 @@ November, 2015 | [Release Notes](https://github.com/PredictionIO/PredictionIO/bl
 
 ###v0.9.5 
 
-October 14th, 2015 | [Release Notes](https://github.com/PredictionIO/PredictionIO/blob/master/RELEASE.md) have been moved to Github and you are reading them. For a detailed list of commits check [this page](https://github.com/PredictionIO/PredictionIO/commits/v0.9.5)
+October 14th, 2015 | [Release Notes](https://github.com/apache/incubator-predictionio/blob/develop/RELEASE.md) have been moved to Github and you are reading them. For a detailed list of commits check [this page](https://github.com/apache/incubator-predictionio/commits/v0.9.5)
 
 - Support batches of events sent to the EventServer as json arrays
 - Support creating an Elasticsearch StorageClient created for an Elasticsearch cluster from variables in pio-env.sh

--- a/docs/manual/source/system/anotherdatastore.html.md
+++ b/docs/manual/source/system/anotherdatastore.html.md
@@ -281,7 +281,7 @@ supported.
 It is quite straightforward to implement support of other backends. A good
 starting point is to reference the JDBC implementation inside the
 [org.apache.predictionio.data.storage.jdbc
-package](https://github.com/PredictionIO/PredictionIO/tree/develop/data/src/main/scala/org.apache.predictionio/data/storage/jdbc).
+package](https://github.com/apache/incubator-predictionio/tree/develop/data/src/main/scala/org/apache/predictionio/data/storage/jdbc).
 
 Contributions of different backends implementation is highly encouraged. To
 start contributing, please refer to [this guide](/community/contribute-code/).

--- a/docs/manual/source/templates/ecommercerecommendation/train-with-rate-event.html.md.erb
+++ b/docs/manual/source/templates/ecommercerecommendation/train-with-rate-event.html.md.erb
@@ -8,7 +8,7 @@ However, recent "view" event is still used for recommendation for new user (to r
 
 This template also supports that the user may rate same item multiple times and latest rating value will be used for training. The modification can be further simplified if the support of this case is not needed.
 
-You can find the complete modified source code [here](https://github.com/PredictionIO/PredictionIO/tree/develop/examples/scala-parallel-ecommercerecommendation/train-with-rate-event) and the modification is based on E-Commerce Recommendation template v0.1.1.
+You can find the complete modified source code [here](https://github.com/apache/incubator-predictionio/tree/develop/examples/scala-parallel-ecommercerecommendation/train-with-rate-event) and the modification is based on E-Commerce Recommendation template v0.1.1.
 
 
 ## Modification

--- a/docs/manual/source/templates/recommendation/customize-data-prep.html.md
+++ b/docs/manual/source/templates/recommendation/customize-data-prep.html.md
@@ -18,7 +18,7 @@ A sample black list file containing the items to be excluded is provided in
 `./data/sample_not_train_data.txt`.
 
 A full end-to-end example can be found on
-[GitHub](https://github.com/PredictionIO/PredictionIO/tree/develop/examples/scala-parallel-recommendation/custom-prepartor).
+[GitHub](https://github.com/apache/incubator-predictionio/tree/develop/examples/scala-parallel-recommendation/custom-prepartor).
 
 ## The Data Preparator Component
 

--- a/docs/manual/source/templates/recommendation/customize-serving.html.md
+++ b/docs/manual/source/templates/recommendation/customize-serving.html.md
@@ -9,7 +9,7 @@ currently in stock from the list of recommendation.
 This section is based on the [Recommendation Engine Template](/templates/recommendation/quickstart/).
 
 A full end-to-end example can be found on
-[GitHub](https://github.com/PredictionIO/PredictionIO/tree/develop/examples/scala-parallel-recommendation/custom-serving).
+[GitHub](https://github.com/apache/incubator-predictionio/tree/develop/examples/scala-parallel-recommendation/custom-serving).
 
 <!--
 This section demonstrates how to add a custom filtering logic to exclude a list

--- a/examples/scala-parallel-similarproduct/add-and-return-item-properties/README.md
+++ b/examples/scala-parallel-similarproduct/add-and-return-item-properties/README.md
@@ -8,7 +8,7 @@ To use this how-to you need to be familiar with scala programming language.
 In this how-to we also suppose you was able to set up and run `Similar Product Engine` (see their [quick start guide](http://predictionio.incubator.apache.org/templates/similarproduct/quickstart/)).
 
 A full end-to-end example can be found on
-[GitHub](https://github.com/PredictionIO/PredictionIO/tree/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties).
+[GitHub](https://github.com/apache/incubator-predictionio/tree/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties).
 
 ## THE TASK
 
@@ -62,7 +62,7 @@ to the `Serving` component where the engine will send required information back 
 ### Implementation
 
 #### Modify The Item
-In file [DataSource.scala#L104](https://github.com/PredictionIO/PredictionIO/blob/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties/src/main/scala/DataSource.scala#L104)
+In file [DataSource.scala#L104](https://github.com/apache/incubator-predictionio/blob/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties/src/main/scala/DataSource.scala#L104)
 you will find class `Item` defined in the next way
 ```scala
 case class Item(categories: Option[List[String]])
@@ -79,7 +79,7 @@ case class Item(
 
 #### Create The Item Properly
 Now, your IDE (or compiler) will say you about all the places where you need make changes to create item
-properly. For example, [DataSource.scala#L52](https://github.com/PredictionIO/PredictionIO/blob/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties/src/main/scala/DataSource.scala#L52)
+properly. For example, [DataSource.scala#L52](https://github.com/apache/incubator-predictionio/blob/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties/src/main/scala/DataSource.scala#L52)
 ```scala
 Item(categories = properties.getOpt[List[String]]("categories"))
 ```
@@ -93,7 +93,7 @@ Item(
 ```
 
 #### Modify The ItemScore
-Now, when you've fixed item creation, take a look on class `ItemScore` from the file [Engine.scala](https://github.com/PredictionIO/PredictionIO/blob/develop/examples/scala-parallel-similarproduct-multi/src/main/scala/Engine.scala)
+Now, when you've fixed item creation, take a look on class `ItemScore` from the file [Engine.scala](https://github.com/apache/incubator-predictionio/blob/develop/examples/scala-parallel-similarproduct/multi/src/main/scala/Engine.scala)
 ```scala
 case class ItemScore(
 	item: String,
@@ -118,7 +118,7 @@ case class ItemScore(
 Again, now you need to go through all the places where `ItemScore` is created and fix compiler errors.
 
 Result is initially created by the `Algorithm` component and then is passed to the `Serving` component.
-Take a look on a place where object of class ItemScore is initially created in file [ALSAlgorithm.scala#L171](https://github.com/PredictionIO/PredictionIO/blob/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties/src/main/scala/ALSAlgorithm.scala#L171).
+Take a look on a place where object of class ItemScore is initially created in file [ALSAlgorithm.scala#L171](https://github.com/apache/incubator-predictionio/blob/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties/src/main/scala/ALSAlgorithm.scala#L173).
 ```scala
 new ItemScore(
 	item = model.itemIntStringMap(i),
@@ -142,7 +142,7 @@ Using `model.itemIntStringMap(i)` you can receive ID of corresponding item.
 
 #### Modify Script That Supplies Data For The Engine
 And this is the final step. You should supply your data to the engine using new format now.
-To get the idea take a look on this piece of code in our [sample python script](https://github.com/PredictionIO/PredictionIO/blob/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties/data/import_eventserver.py#L34)
+To get the idea take a look on this piece of code in our [sample python script](https://github.com/apache/incubator-predictionio/blob/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties/data/import_eventserver.py#L34)
 that creates test.
 
 Creating item before modification.
@@ -185,4 +185,4 @@ curl -H "Content-Type: application/json" -d '{ "items": ["i1", "i3"], "num": 10}
 ```
 
 A full end-to-end example can be found on
-[GitHub](https://github.com/PredictionIO/PredictionIO/tree/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties).
+[GitHub](https://github.com/apache/incubator-predictionio/tree/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties)

--- a/examples/scala-parallel-similarproduct/add-and-return-item-properties/README.md
+++ b/examples/scala-parallel-similarproduct/add-and-return-item-properties/README.md
@@ -118,7 +118,7 @@ case class ItemScore(
 Again, now you need to go through all the places where `ItemScore` is created and fix compiler errors.
 
 Result is initially created by the `Algorithm` component and then is passed to the `Serving` component.
-Take a look on a place where object of class ItemScore is initially created in file [ALSAlgorithm.scala#L171](https://github.com/apache/incubator-predictionio/blob/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties/src/main/scala/ALSAlgorithm.scala#L173).
+Take a look on a place where object of class ItemScore is initially created in file [ALSAlgorithm.scala#L171](https://github.com/apache/incubator-predictionio/blob/develop/examples/scala-parallel-similarproduct/add-and-return-item-properties/src/main/scala/ALSAlgorithm.scala#L171).
 ```scala
 new ItemScore(
 	item = model.itemIntStringMap(i),


### PR DESCRIPTION
This PR changes Github links correctly across documentation.

Mainly the change is, 

- from: `https://github.com/`**`PredictionIO/PredictionIO`**`/...`

- to: `https://github.com/`**`apache/incubator-predictionio`**`/...`
