### PR TITLE
[ PIO-19 ] changed mistyped admin-server-port to admin-server-ip

### DIFF
--- a/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
@@ -338,7 +338,7 @@ object Console extends Logging {
           opt[Int]("admin-server-port") action { (x, c) =>
             c.copy(adminServer = c.adminServer.copy(port = x))
           } text("Admin server port. Default: 7071"),
-          opt[String]("admin-server-port") action { (x, c) =>
+          opt[String]("admin-server-ip") action { (x, c) =>
           c.copy(adminServer = c.adminServer.copy(ip = x))
           } text("Admin server IP. Default: localhost"),
           opt[String]("accesskey") action { (x, c) =>


### PR DESCRIPTION
the option for admin server ip in pio deploy command is written as admin-server-port, changed that to admin-server-ip.