### PR TITLE
specify the output file explicitely when installing via install.sh script

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -298,7 +298,7 @@ cd ${TEMP_DIR}
 
 if [[ ! -e ${PIO_FILE} ]]; then
   echo "Downloading PredictionIO..."
-  curl -OL https://codeload.github.com/apache/incubator-predictionio/tar.gz/develop
+  curl -L https://codeload.github.com/apache/incubator-predictionio/tar.gz/develop > incubator-predictionio-develop.tar.gz 
 
   tar zxf incubator-predictionio-develop.tar.gz 
 


### PR DESCRIPTION
the `-O` option on my system has downloaded the file to `develop` instead of the *.tar.gz file that is used later in the script