### PR TITLE
[PIO-26] BUG: Put license before XML declaration

### DIFF
--- a/tests/docker-files/env-conf/hbase-site.xml
+++ b/tests/docker-files/env-conf/hbase-site.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +16,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<?xml version="1.0"?>
-<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <configuration>
   <property>
     <name>hbase.rootdir</name>


### PR DESCRIPTION
This creates errors when updating Docker image