### PR TITLE
[PIO-46] Fix readlink with -f option not working on BSD based systems

### DIFF
--- a/bin/pio
+++ b/bin/pio
@@ -32,7 +32,26 @@ search() {
   echo ${i}
 }
 
-export PIO_HOME="$(cd $(dirname $(readlink -f $0))/..; pwd)"
+PIO_FILE=$(readlink -f $0 2>/dev/null)
+if [ $? = 0 ] ; then 
+  export PIO_HOME="$(cd $(dirname $PIO_FILE)/..; pwd)"
+else
+  CURRENT_DIR=`pwd`
+  TARGET_FILE="$0"
+  cd "$(dirname "$TARGET_FILE")"
+  TARGET_FILE=$(basename "$TARGET_FILE")
+
+  while [ -L "$TARGET_FILE" ]
+  do
+    TARGET_FILE=$(readlink "$TARGET_FILE")
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE=$(basename "$TARGET_FILE")
+  done
+
+  export PIO_HOME="$(cd $(dirname "$TARGET_FILE")/..; pwd -P)"
+  cd "$CURRENT_DIR"
+fi
+
 
 export PIO_CONF_DIR="${PIO_HOME}/conf"
 


### PR DESCRIPTION
Thanks for pio script's supporting soft link.
https://github.com/apache/incubator-predictionio/pull/289

But `readlink -f` doesn't seem to work on Mac and possibly BSD based systems. 
As execute pio script, the following errors occurs.

```
readlink: illegal option -- f
usage: readlink [-n] [file ...]
usage: dirname path
bin/pio: line 45: //bin/pio-class: No such file or directory
bin/pio: line 45: exec: //bin/pio-class: cannot execute: No such file or directory
```

I had fixed pio script not to use readlink with option -f , based on this sbt script.
https://github.com/apache/incubator-predictionio/blob/d45d0a4170ef73695e0fffe921e5bda2c37e2281/sbt/sbt#L8-L32
