### PR TITLE
[PIO-41] Fixed sbt so that test cases can run

### DIFF
--- a/data/build.sbt
+++ b/data/build.sbt
@@ -51,7 +51,8 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc"        %% "scalikejdbc"    % "2.3.5",
   "org.slf4j"               % "slf4j-log4j12"  % "1.7.18",
   "org.spark-project.akka" %% "akka-actor"     % "2.3.4-spark",
-  "org.specs2"             %% "specs2"         % "2.3.13" % "test")
+  "org.specs2"             %% "specs2"         % "2.3.13" % "test",
+  "com.typesafe.akka" %% "akka-slf4j" % "2.3.6")
 
 parallelExecution in Test := false
 

--- a/data/src/main/resources/log4j.properties
+++ b/data/src/main/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
[PIO-41] Missing sbt entry for akka-sl4j and  [#log4j.properties] [JIRA Link](https://issues.apache.org/jira/browse/PIO-41)

Was not able to run test cases, missing entry in data/build.sbt

"com.typesafe.akka" %% "akka-slf4j" % "2.3.6"

Also missing log4j.properties in data/src/main/resources folder