### PR TITLE
Unit is not Unit value

### DIFF
--- a/core/src/main/scala/org/apache/predictionio/controller/Engine.scala
+++ b/core/src/main/scala/org/apache/predictionio/controller/Engine.scala
@@ -208,7 +208,7 @@ class Engine[TD, EI, PD, Q, P, A](
       Doer(algorithmClassMap(algoName), algoParams)
     }
 
-    val models = if (persistedModels.exists(m => m.isInstanceOf[Unit.type])) {
+    val models = if (persistedModels.exists(m => m.isInstanceOf[Unit])) {
       // If any of persistedModels is Unit, we need to re-train the model.
       logger.info("Some persisted models are Unit, need to re-train.")
       val (dataSourceName, dataSourceParams) = engineParams.dataSourceParams
@@ -222,7 +222,7 @@ class Engine[TD, EI, PD, Q, P, A](
 
       val models = algorithms.zip(persistedModels).map { case (algo, m) =>
         m match {
-          case Unit => algo.trainBase(sc, pd)
+          case () => algo.trainBase(sc, pd)
           case _ => m
         }
       }

--- a/core/src/main/scala/org/apache/predictionio/controller/LAlgorithm.scala
+++ b/core/src/main/scala/org/apache/predictionio/controller/LAlgorithm.scala
@@ -124,7 +124,7 @@ abstract class LAlgorithm[PD, M : ClassTag, Q, P]
         modelId, algoParams, sc)) {
         PersistentModelManifest(className = m.getClass.getName)
       } else {
-        Unit
+        ()
       }
     } else {
       m

--- a/core/src/main/scala/org/apache/predictionio/controller/P2LAlgorithm.scala
+++ b/core/src/main/scala/org/apache/predictionio/controller/P2LAlgorithm.scala
@@ -115,7 +115,7 @@ abstract class P2LAlgorithm[PD, M: ClassTag, Q: ClassTag, P]
         modelId, algoParams, sc)) {
         PersistentModelManifest(className = m.getClass.getName)
       } else {
-        Unit
+        ()
       }
     } else {
       m

--- a/core/src/main/scala/org/apache/predictionio/controller/PAlgorithm.scala
+++ b/core/src/main/scala/org/apache/predictionio/controller/PAlgorithm.scala
@@ -120,10 +120,10 @@ abstract class PAlgorithm[PD, M, Q, P]
         modelId, algoParams, sc)) {
         PersistentModelManifest(className = m.getClass.getName)
       } else {
-        Unit
+        ()
       }
     } else {
-      Unit
+      ()
     }
   }
 }

--- a/core/src/main/scala/org/apache/predictionio/core/BaseAlgorithm.scala
+++ b/core/src/main/scala/org/apache/predictionio/core/BaseAlgorithm.scala
@@ -112,7 +112,7 @@ abstract class BaseAlgorithm[PD, M, Q, P]
     sc: SparkContext,
     modelId: String,
     algoParams: Params,
-    bm: Any): Any = Unit
+    bm: Any): Any = ()
 
   /** :: DeveloperApi ::
     * Obtains the type signature of query for this algorithm

--- a/core/src/main/scala/org/apache/predictionio/workflow/CreateServer.scala
+++ b/core/src/main/scala/org/apache/predictionio/workflow/CreateServer.scala
@@ -268,7 +268,7 @@ class MasterActor (
         .param(ServerKey.param, ServerKey.get)
         .method("POST").asString.code
       code match {
-        case 200 => Unit
+        case 200 => ()
         case 404 => log.error(
           s"Another process is using $serverUrl. Unable to undeploy.")
         case _ => log.error(

--- a/core/src/main/scala/org/apache/predictionio/workflow/FakeWorkflow.scala
+++ b/core/src/main/scala/org/apache/predictionio/workflow/FakeWorkflow.scala
@@ -102,7 +102,7 @@ trait FakeRun extends Evaluation with EngineParamsGenerator {
     engineParamsList = Seq(new EngineParams())
   }
 
-  def func: (SparkContext => Unit) = { (sc: SparkContext) => Unit }
+  def func: (SparkContext => Unit) = { (sc: SparkContext) => () }
   def func_=(f: SparkContext => Unit) {
     runner = new FakeRunner(f)
   }

--- a/core/src/test/scala/org/apache/predictionio/controller/EngineTest.scala
+++ b/core/src/test/scala/org/apache/predictionio/controller/EngineTest.scala
@@ -60,7 +60,7 @@ extends FunSuite with Inside with SharedSparkContext {
 
     // PAlgo2.Model doesn't have IPersistentModel trait implemented. Hence the
     // model extract after train is Unit.
-    models should contain theSameElementsAs Seq(Unit)
+    models should contain theSameElementsAs Seq(())
   }
 
   test("Engine.train persisting PAlgo.Model") {
@@ -96,7 +96,7 @@ extends FunSuite with Inside with SharedSparkContext {
     val pModel21 = PersistentModelManifest(model21.getClass.getName)
     val pModel22 = PersistentModelManifest(model22.getClass.getName)
     
-    models should contain theSameElementsAs Seq(Unit, pModel21, pModel22)
+    models should contain theSameElementsAs Seq((), pModel21, pModel22)
   }
 
   test("Engine.train persisting LAlgo.Model") {
@@ -181,7 +181,7 @@ extends FunSuite with Inside with SharedSparkContext {
     val pModel23 = PersistentModelManifest(model23.getClass.getName)
     
     models should contain theSameElementsAs Seq(
-      Unit, pModel21, pModel22, pModel23, model24, model25)
+      (), pModel21, pModel22, pModel23, model24, model25)
   }
 
   test("Engine.eval") {

--- a/tools/src/main/scala/org/apache/predictionio/tools/Runner.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/Runner.scala
@@ -73,7 +73,7 @@ object Runner extends EitherLogging {
     (fs, uri) match {
       case (Some(f), Some(u)) =>
         f.close()
-      case _ => Unit
+      case _ => ()
     }
   }
 
@@ -114,7 +114,7 @@ object Runner extends EitherLogging {
       case (_, "cluster", m) if m.startsWith("spark://") =>
         return logAndFail(
           "Using cluster deploy mode with Spark standalone cluster is not supported")
-      case _ => Unit
+      case _ => ()
     }
 
     // Initialize HDFS API for scratch URI


### PR DESCRIPTION
`Unit` is not Unit value. `()` is an only value of Unit type in Scala.

```
scala> Unit
res1: Unit.type = object scala.Unit

scala> () == Unit
<console>:12: warning: comparing values of types Unit and Unit.type using `==' will always yield false
       () == Unit
          ^
res2: Boolean = false
```