### PR TITLE
[PIO-51] Properly locate engine directory

### DIFF
--- a/tools/src/main/scala/org/apache/predictionio/tools/RunServer.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/RunServer.scala
@@ -47,7 +47,7 @@ case class ServerArgs(
   eventServer: EventServerArgs = EventServerArgs(),
   batch: String = "",
   accessKey: String = "",
-  variantJson: File = new File("engine.json"),
+  variantJson: Option[File] = None,
   jsonExtractor: JsonExtractorOption = JsonExtractorOption.Both)
 
 
@@ -68,7 +68,8 @@ object RunServer extends Logging {
       "--engineInstanceId",
       engineInstanceId,
       "--engine-variant",
-      engineDirPath + File.separator + serverArgs.variantJson.getName,
+      serverArgs.variantJson.getOrElse(
+        new File(engineDirPath, "engine.json")).getCanonicalPath,
       "--ip",
       serverArgs.deploy.ip,
       "--port",

--- a/tools/src/main/scala/org/apache/predictionio/tools/RunWorkflow.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/RunWorkflow.scala
@@ -56,15 +56,16 @@ object RunWorkflow extends Logging {
     verbose: Boolean = false): Expected[(Process, () => Unit)] = {
 
     val jarFiles = jarFilesForScala(engineDirPath).map(_.toURI)
-    val variantJson = engineDirPath + File.separator + wa.variantJson.getName
-    val ei = Console.getEngineInfo(new File(variantJson))
+    val ei = Console.getEngineInfo(
+      wa.variantJson,
+      engineDirPath)
     val args = Seq(
       "--engine-id",
       ei.engineId,
       "--engine-version",
       ei.engineVersion,
       "--engine-variant",
-      variantJson,
+      wa.variantJson.toURI.toString,
       "--verbosity",
       wa.verbosity.toString) ++
       wa.engineFactory.map(

--- a/tools/src/main/scala/org/apache/predictionio/tools/RunWorkflow.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/RunWorkflow.scala
@@ -36,7 +36,7 @@ import scala.sys.process._
 
 case class WorkflowArgs(
   batch: String = "",
-  variantJson: File = new File("engine.json"),
+  variantJson: Option[File] = None,
   verbosity: Int = 0,
   engineParamsKey: Option[String] = None,
   engineFactory: Option[String] = None,
@@ -56,8 +56,9 @@ object RunWorkflow extends Logging {
     verbose: Boolean = false): Expected[(Process, () => Unit)] = {
 
     val jarFiles = jarFilesForScala(engineDirPath).map(_.toURI)
+    val variantJson = wa.variantJson.getOrElse(new File(engineDirPath, "engine.json"))
     val ei = Console.getEngineInfo(
-      wa.variantJson,
+      variantJson,
       engineDirPath)
     val args = Seq(
       "--engine-id",
@@ -65,7 +66,7 @@ object RunWorkflow extends Logging {
       "--engine-version",
       ei.engineVersion,
       "--engine-variant",
-      wa.variantJson.toURI.toString,
+      variantJson.toURI.toString,
       "--verbosity",
       wa.verbosity.toString) ++
       wa.engineFactory.map(

--- a/tools/src/main/scala/org/apache/predictionio/tools/commands/Engine.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/commands/Engine.scala
@@ -222,7 +222,7 @@ object Engine extends EitherLogging {
       return Left(verifyResult.left.get)
     }
     val ei = Console.getEngineInfo(
-      serverArgs.variantJson,
+      serverArgs.variantJson.getOrElse(new File(engineDirPath, "engine.json")),
       engineDirPath)
     val engineInstances = storage.Storage.getMetaDataEngineInstances
     val engineInstance = engineInstanceId map { eid =>

--- a/tools/src/main/scala/org/apache/predictionio/tools/commands/Engine.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/commands/Engine.scala
@@ -222,7 +222,8 @@ object Engine extends EitherLogging {
       return Left(verifyResult.left.get)
     }
     val ei = Console.getEngineInfo(
-      new File(engineDirPath, serverArgs.variantJson.getName))
+      serverArgs.variantJson,
+      engineDirPath)
     val engineInstances = storage.Storage.getMetaDataEngineInstances
     val engineInstance = engineInstanceId map { eid =>
       engineInstances.get(eid)

--- a/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
@@ -734,7 +734,7 @@ object Console extends Logging {
     }
   }
 
-  def getEngineInfo(jsonFile: File): EngineInfo = {
+  def getEngineInfo(jsonFile: File, engineDir: String): EngineInfo = {
     // Use engineFactory as engineId
     val variantJson = parse(Source.fromFile(jsonFile).mkString)
     val engineId = variantJson \ "engineFactory" match {
@@ -754,7 +754,6 @@ object Console extends Logging {
     }
 
     // Use hash of engine directory as engineVersion
-    val engineDir = sys.props("user.dir")
     val engineVersion = java.security.MessageDigest.getInstance("SHA-1").
       digest(engineDir.getBytes).map("%02x".format(_)).mkString
 

--- a/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
@@ -120,10 +120,9 @@ object Console extends Logging {
         "deployment.")
       opt[String]("engine-dir") abbr("ed") action { (x, c) =>
         c.copy(engine = c.engine.copy(engineDir = Some(x)))
-      } text("Specify absolute path for engine directory, default to " +
-        "current directory.")
+      } text("Specify path for engine directory, default to current directory.")
       opt[File]("variant") abbr("v") action { (x, c) =>
-        c.copy(workflow = c.workflow.copy(variantJson = x))
+        c.copy(workflow = c.workflow.copy(variantJson = Some(x)))
       }
       opt[File]("sbt") action { (x, c) =>
         c.copy(build = c.build.copy(sbt = Some(x)))


### PR DESCRIPTION
When --engine-dir is passed as CLI argument, use this instead of
user.dir