### PR TITLE
[PIO-30] Spark 2 support on sbt way

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,12 @@ javacOptions in (ThisBuild, compile) ++= Seq("-source", "1.7", "-target", "1.7",
 
 json4sVersion in ThisBuild := "3.2.10"
 
-sparkVersion in ThisBuild := "2.1.0"
+sparkVersion in ThisBuild := {
+  scalaBinaryVersion.value match {
+    case "2.10" => "1.6.3"
+    case _ => "2.1.0"
+  }
+}
 
 val pioBuildInfoSettings = buildInfoSettings ++ Seq(
   sourceGenerators in Compile <+= buildInfo,

--- a/build.sbt
+++ b/build.sbt
@@ -15,15 +15,15 @@
  * limitations under the License.
  */
 
-import UnidocKeys._
-
 name := "apache-predictionio-parent"
 
-version in ThisBuild := "0.11.0-SNAPSHOT"
+version in ThisBuild := "0.11.0-v1-SNAPSHOT"
 
 organization in ThisBuild := "org.apache.predictionio"
 
 scalaVersion in ThisBuild := "2.10.5"
+
+crossScalaVersions in ThisBuild := Seq(scalaVersion.value, "2.11.8")
 
 scalacOptions in ThisBuild ++= Seq("-deprecation", "-unchecked", "-feature")
 
@@ -36,16 +36,13 @@ javacOptions in (ThisBuild, compile) ++= Seq("-source", "1.7", "-target", "1.7",
 
 json4sVersion in ThisBuild := "3.2.10"
 
-sparkVersion in ThisBuild := "1.6.3"
+sparkVersion in ThisBuild := "2.1.0"
 
 val pioBuildInfoSettings = buildInfoSettings ++ Seq(
   sourceGenerators in Compile <+= buildInfo,
   buildInfoKeys := Seq[BuildInfoKey](
-    name,
     version,
-    scalaVersion,
-    sbtVersion,
-    sparkVersion),
+    scalaBinaryVersion),
   buildInfoPackage := "org.apache.predictionio.core")
 
 val conf = file("conf")
@@ -56,59 +53,58 @@ val commonSettings = Seq(
 
 val common = (project in file("common")).
   settings(commonSettings: _*).
-  settings(genjavadocSettings: _*)
+  enablePlugins(GenJavadocPlugin)
 
 val data = (project in file("data")).
   dependsOn(common).
   settings(commonSettings: _*).
-  settings(genjavadocSettings: _*)
+  enablePlugins(GenJavadocPlugin)
 
 val dataElasticsearch1 = (project in file("storage/elasticsearch1")).
   settings(commonSettings: _*).
-  settings(genjavadocSettings: _*)
+  enablePlugins(GenJavadocPlugin)
 
 val dataElasticsearch = (project in file("storage/elasticsearch")).
   settings(commonSettings: _*).
-  settings(genjavadocSettings: _*)
+  enablePlugins(GenJavadocPlugin)
 
 val dataHbase = (project in file("storage/hbase")).
   settings(commonSettings: _*).
-  settings(genjavadocSettings: _*)
+  enablePlugins(GenJavadocPlugin)
 
 val dataHdfs = (project in file("storage/hdfs")).
   settings(commonSettings: _*).
-  settings(genjavadocSettings: _*)
+  enablePlugins(GenJavadocPlugin)
 
 val dataJdbc = (project in file("storage/jdbc")).
   settings(commonSettings: _*).
-  settings(genjavadocSettings: _*)
+  enablePlugins(GenJavadocPlugin)
 
 val dataLocalfs = (project in file("storage/localfs")).
   settings(commonSettings: _*).
-  settings(genjavadocSettings: _*)
+  enablePlugins(GenJavadocPlugin)
 
 val core = (project in file("core")).
   dependsOn(data).
   settings(commonSettings: _*).
-  settings(genjavadocSettings: _*).
+  enablePlugins(GenJavadocPlugin).
   settings(pioBuildInfoSettings: _*).
   enablePlugins(SbtTwirl)
 
 val tools = (project in file("tools")).
-  dependsOn(core).
-  dependsOn(data).
   settings(commonSettings: _*).
-  settings(genjavadocSettings: _*).
+  enablePlugins(GenJavadocPlugin).
   enablePlugins(SbtTwirl)
 
 val e2 = (project in file("e2")).
   settings(commonSettings: _*).
-  settings(genjavadocSettings: _*)
+  enablePlugins(GenJavadocPlugin)
 
 val root = (project in file(".")).
   settings(commonSettings: _*).
+  enablePlugins(ScalaUnidocPlugin).
+  enablePlugins(JavaUnidocPlugin).
   // settings(scalaJavaUnidocSettings: _*).
-  settings(unidocSettings: _*).
   settings(
     scalacOptions in (ScalaUnidoc, unidoc) ++= Seq(
       "-groups",

--- a/common/build.sbt
+++ b/common/build.sbt
@@ -18,8 +18,8 @@
 name := "apache-predictionio-common"
 
 libraryDependencies ++= Seq(
-  "io.spray"               %% "spray-can"        % "1.3.2",
-  "io.spray"               %% "spray-routing"    % "1.3.2",
+  "io.spray"               %% "spray-can"        % "1.3.3",
+  "io.spray"               %% "spray-routing"    % "1.3.3",
   "org.spark-project.akka" %% "akka-actor"     % "2.3.4-spark"
 )
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -20,26 +20,15 @@ name := "apache-predictionio-core"
 libraryDependencies ++= Seq(
   "com.github.scopt"       %% "scopt"            % "3.3.0",
   "com.google.code.gson"    % "gson"             % "2.5",
-  "com.google.guava"        % "guava"            % "18.0",
-  "com.twitter"            %% "chill"            % "0.7.2"
-    exclude("com.esotericsoftware.minlog", "minlog"),
   "com.twitter"            %% "chill-bijection"  % "0.7.2",
   "de.javakaffee"           % "kryo-serializers" % "0.37",
-  "commons-io"              % "commons-io"       % "2.4",
-  "io.spray"               %% "spray-can"        % "1.3.3",
-  "io.spray"               %% "spray-routing"    % "1.3.3",
   "net.jodah"               % "typetools"        % "0.3.1",
   "org.apache.spark"       %% "spark-core"       % sparkVersion.value % "provided",
-  "org.apache.spark"       %% "spark-sql"        % sparkVersion.value % "provided",
-  "org.clapper"            %% "grizzled-slf4j"   % "1.0.2",
-  "org.json4s"             %% "json4s-native"    % json4sVersion.value,
   "org.json4s"             %% "json4s-ext"       % json4sVersion.value,
   "org.scalaj"             %% "scalaj-http"      % "1.1.6",
   "org.scalatest"          %% "scalatest"        % "2.1.7" % "test",
   "org.slf4j"               % "slf4j-log4j12"    % "1.7.18",
   "org.specs2"             %% "specs2"           % "2.3.13" % "test")
-
-//testOptions := Seq(Tests.Filter(s => Seq("Dev").exists(s.contains(_))))
 
 parallelExecution in Test := false
 

--- a/data/build.sbt
+++ b/data/build.sbt
@@ -19,24 +19,13 @@ name := "apache-predictionio-data"
 
 libraryDependencies ++= Seq(
   "com.github.nscala-time" %% "nscala-time"    % "2.6.0",
-  "commons-codec"           % "commons-codec"  % "1.9",
   "io.spray"               %% "spray-can"      % "1.3.3",
   "io.spray"               %% "spray-routing"  % "1.3.3",
   "io.spray"               %% "spray-testkit"  % "1.3.3" % "test",
-  "mysql"                   % "mysql-connector-java" % "5.1.37" % "optional",
-  "org.apache.hadoop"       % "hadoop-common"  % "2.6.2"
-    exclude("javax.servlet", "servlet-api"),
-  "org.apache.zookeeper"    % "zookeeper"      % "3.4.7"
-    exclude("org.slf4j", "slf4j-api")
-    exclude("org.slf4j", "slf4j-log4j12"),
-  "org.apache.spark"       %% "spark-core"     % sparkVersion.value % "provided",
   "org.apache.spark"       %% "spark-sql"      % sparkVersion.value % "provided",
   "org.clapper"            %% "grizzled-slf4j" % "1.0.2",
   "org.json4s"             %% "json4s-native"  % json4sVersion.value,
-  "org.json4s"             %% "json4s-ext"     % json4sVersion.value,
   "org.scalatest"          %% "scalatest"      % "2.1.7" % "test",
-  "org.slf4j"               % "slf4j-log4j12"  % "1.7.18",
-  "org.spark-project.akka" %% "akka-actor"     % "2.3.4-spark",
   "org.specs2"             %% "specs2"         % "2.3.13" % "test")
 
 parallelExecution in Test := false

--- a/e2/build.sbt
+++ b/e2/build.sbt
@@ -20,9 +20,7 @@ name := "apache-predictionio-e2"
 parallelExecution in Test := false
 
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided",
   "org.apache.spark" %% "spark-mllib" % sparkVersion.value % "provided",
-  "org.clapper" %% "grizzled-slf4j" % "1.0.2",
-  "org.scalatest" %% "scalatest" % "2.2.5" % "test")
+  "org.scalatest"    %% "scalatest" % "2.2.5" % "test")
 
 pomExtra := childrenPomExtra.value

--- a/project/unidoc.sbt
+++ b/project/unidoc.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.0")

--- a/storage/elasticsearch/build.sbt
+++ b/storage/elasticsearch/build.sbt
@@ -21,30 +21,18 @@ elasticsearchVersion := "5.2.1"
 
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % version.value % "provided",
-  "org.apache.predictionio" %% "apache-predictionio-data" % version.value % "provided",
   "org.apache.spark"        %% "spark-core"     % sparkVersion.value % "provided",
-  "org.apache.spark"        %% "spark-sql"      % sparkVersion.value % "provided",
   "org.elasticsearch.client" % "rest"           % elasticsearchVersion.value,
-  "org.elasticsearch"       %% "elasticsearch-spark-13" % elasticsearchVersion.value
-    exclude("org.apache.spark", "spark-sql_2.10")
-    exclude("org.apache.spark", "spark-streaming_2.10"),
+  "org.elasticsearch"       %% "elasticsearch-spark-20" % elasticsearchVersion.value
+    exclude("org.apache.spark", "*"),
   "org.elasticsearch"        % "elasticsearch-hadoop-mr" % elasticsearchVersion.value,
-  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test",
-  "org.specs2"              %% "specs2"         % "2.3.13" % "test")
+  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test")
 
 parallelExecution in Test := false
 
 pomExtra := childrenPomExtra.value
 
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeDependency = true)
-
-assemblyMergeStrategy in assembly := {
-  case PathList("META-INF", "LICENSE.txt") => MergeStrategy.concat
-  case PathList("META-INF", "NOTICE.txt")  => MergeStrategy.concat
-  case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
-    oldStrategy(x)
-}
+assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 assemblyShadeRules in assembly := Seq(
   ShadeRule.rename("org.apache.http.**" -> "shadeio.data.http.@1").inAll
@@ -53,4 +41,5 @@ assemblyShadeRules in assembly := Seq(
 // skip test in assembly
 test in assembly := {}
 
-assemblyOutputPath := baseDirectory.value.getAbsoluteFile.getParentFile.getParentFile / "assembly" / "spark" / ("pio-data-elasticsearch-assembly-" + version.value + ".jar")
+assemblyOutputPath in assembly := baseDirectory.value.getAbsoluteFile.getParentFile.getParentFile /
+  "assembly" / scalaBinaryVersion.value / "spark" / s"pio-data-elasticsearch-assembly-${version.value}.jar"

--- a/storage/elasticsearch1/build.sbt
+++ b/storage/elasticsearch1/build.sbt
@@ -21,27 +21,17 @@ elasticsearchVersion := "1.7.3"
 
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % version.value % "provided",
-  "org.apache.predictionio" %% "apache-predictionio-data" % version.value % "provided",
   "org.elasticsearch"        % "elasticsearch"  % elasticsearchVersion.value,
-  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test",
-  "org.specs2"              %% "specs2"         % "2.3.13" % "test")
+  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test")
 
 parallelExecution in Test := false
 
 pomExtra := childrenPomExtra.value
 
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeDependency = true)
-
-assemblyMergeStrategy in assembly := {
-  case PathList("META-INF", "LICENSE.txt") => MergeStrategy.concat
-  case PathList("META-INF", "NOTICE.txt")  => MergeStrategy.concat
-  case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
-    oldStrategy(x)
-}
+assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 // skip test in assembly
 test in assembly := {}
 
-assemblyOutputPath := baseDirectory.value.getAbsoluteFile.getParentFile.getParentFile / "assembly" / "spark" / ("pio-data-elasticsearch1-assembly-" + version.value + ".jar")
-
+assemblyOutputPath in assembly := baseDirectory.value.getAbsoluteFile.getParentFile.getParentFile /
+  "assembly" / scalaBinaryVersion.value / "spark" / s"pio-data-elasticsearch1-assembly-${version.value}.jar"

--- a/storage/hbase/build.sbt
+++ b/storage/hbase/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
     exclude("org.mortbay.jetty", "servlet-api-2.5")
     exclude("org.mortbay.jetty", "jsp-api-2.1")
     exclude("org.mortbay.jetty", "jsp-2.1"),
-  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test")
+  "org.specs2"              %% "specs2"         % "2.3.13" % "test")
 
 parallelExecution in Test := false
 

--- a/storage/hbase/build.sbt
+++ b/storage/hbase/build.sbt
@@ -19,7 +19,6 @@ name := "apache-predictionio-data-hbase"
 
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % version.value % "provided",
-  "org.apache.predictionio" %% "apache-predictionio-data" % version.value % "provided",
   "org.apache.spark"        %% "spark-core"     % sparkVersion.value % "provided",
   "org.apache.hbase"         % "hbase-common"   % "0.98.5-hadoop2",
   "org.apache.hbase"         % "hbase-client"   % "0.98.5-hadoop2"
@@ -32,25 +31,16 @@ libraryDependencies ++= Seq(
     exclude("org.mortbay.jetty", "servlet-api-2.5")
     exclude("org.mortbay.jetty", "jsp-api-2.1")
     exclude("org.mortbay.jetty", "jsp-2.1"),
-  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test",
-  "org.specs2"              %% "specs2"         % "2.3.13" % "test")
+  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test")
 
 parallelExecution in Test := false
 
 pomExtra := childrenPomExtra.value
 
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeDependency = true)
-
-assemblyMergeStrategy in assembly := {
-  case PathList("META-INF", "LICENSE.txt") => MergeStrategy.concat
-  case PathList("META-INF", "NOTICE.txt")  => MergeStrategy.concat
-  case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
-    oldStrategy(x)
-}
+assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 // skip test in assembly
 test in assembly := {}
 
-assemblyOutputPath := baseDirectory.value.getAbsoluteFile.getParentFile.getParentFile / "assembly" / "spark" / ("pio-data-hbase-assembly-" + version.value + ".jar")
-
+assemblyOutputPath in assembly := baseDirectory.value.getAbsoluteFile.getParentFile.getParentFile /
+  "assembly" / scalaBinaryVersion.value / "spark" / s"pio-data-hbase-assembly-${version.value}.jar"

--- a/storage/jdbc/build.sbt
+++ b/storage/jdbc/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "mysql"                    % "mysql-connector-java" % "5.1.37" % "optional",
   "org.postgresql"           % "postgresql"     % "9.4-1204-jdbc41",
   "org.scalikejdbc"         %% "scalikejdbc"    % "2.3.5",
-  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test")
+  "org.specs2"              %% "specs2"         % "2.3.13" % "test")
 
 parallelExecution in Test := false
 

--- a/storage/jdbc/build.sbt
+++ b/storage/jdbc/build.sbt
@@ -19,29 +19,20 @@ name := "apache-predictionio-data-jdbc"
 
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % version.value % "provided",
-  "org.apache.predictionio" %% "apache-predictionio-data" % version.value % "provided",
   "org.apache.spark"        %% "spark-sql"      % sparkVersion.value % "provided",
+  "mysql"                    % "mysql-connector-java" % "5.1.37" % "optional",
   "org.postgresql"           % "postgresql"     % "9.4-1204-jdbc41",
   "org.scalikejdbc"         %% "scalikejdbc"    % "2.3.5",
-  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test",
-  "org.specs2"              %% "specs2"         % "2.3.13" % "test")
+  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test")
 
 parallelExecution in Test := false
 
 pomExtra := childrenPomExtra.value
 
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeDependency = true)
-
-assemblyMergeStrategy in assembly := {
-  case PathList("META-INF", "LICENSE.txt") => MergeStrategy.concat
-  case PathList("META-INF", "NOTICE.txt")  => MergeStrategy.concat
-  case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
-    oldStrategy(x)
-}
+assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 // skip test in assembly
 test in assembly := {}
 
-assemblyOutputPath := baseDirectory.value.getAbsoluteFile.getParentFile.getParentFile / "assembly" / "spark" / ("pio-data-jdbc-assembly-" + version.value + ".jar")
-
+assemblyOutputPath in assembly := baseDirectory.value.getAbsoluteFile.getParentFile.getParentFile /
+  "assembly" / scalaBinaryVersion.value / "spark" / s"pio-data-jdbc-assembly-${version.value}.jar"

--- a/storage/localfs/build.sbt
+++ b/storage/localfs/build.sbt
@@ -19,26 +19,16 @@ name := "apache-predictionio-data-localfs"
 
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % version.value % "provided",
-  "org.apache.predictionio" %% "apache-predictionio-data" % version.value % "provided",
-  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test",
-  "org.specs2"              %% "specs2"         % "2.3.13" % "test")
+  "org.scalatest"           %% "scalatest"      % "2.1.7" % "test")
 
 parallelExecution in Test := false
 
 pomExtra := childrenPomExtra.value
 
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeDependency = true)
-
-assemblyMergeStrategy in assembly := {
-  case PathList("META-INF", "LICENSE.txt") => MergeStrategy.concat
-  case PathList("META-INF", "NOTICE.txt")  => MergeStrategy.concat
-  case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
-    oldStrategy(x)
-}
+assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 // skip test in assembly
 test in assembly := {}
 
-assemblyOutputPath := baseDirectory.value.getAbsoluteFile.getParentFile.getParentFile / "assembly" / "spark" / ("pio-data-localfs-assembly-" + version.value + ".jar")
-
+assemblyOutputPath in assembly := baseDirectory.value.getAbsoluteFile.getParentFile.getParentFile /
+  "assembly" / scalaBinaryVersion.value / "spark" / s"pio-data-localfs-assembly-${version.value}.jar"

--- a/tests/build-docker.sh
+++ b/tests/build-docker.sh
@@ -36,6 +36,9 @@ else
 fi
 sbt/sbt clean
 mkdir assembly
+# TODO: Now, existing pattern flows only
+rm -rf dist/* \
+  && tar zxvf `find . -name 'PredictionIO_2.10-*.tar.gz' -type f` -C dist --strip-components 1
 cp dist/lib/*.jar assembly/
 mkdir -p lib/spark
 cp dist/lib/spark/*.jar lib/spark

--- a/tools/build.sbt
+++ b/tools/build.sbt
@@ -22,6 +22,7 @@ name := "apache-predictionio-tools"
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % version.value,
   "me.lessis"                % "semverfi_2.10"  % "0.1.3",
+  "org.spark-project.akka"  %% "akka-slf4j"     % "2.3.4-spark",
   "org.apache.spark"        %% "spark-sql"      % sparkVersion.value % "provided",
   "io.spray"                %% "spray-testkit"  % "1.3.3" % "test",
   "org.specs2"              %% "specs2"         % "2.3.13" % "test"

--- a/tools/build.sbt
+++ b/tools/build.sbt
@@ -20,41 +20,17 @@ import sbtassembly.AssemblyPlugin.autoImport._
 name := "apache-predictionio-tools"
 
 libraryDependencies ++= Seq(
-  "com.github.scopt"       %% "scopt"          % "3.2.0",
-  "io.spray"               %% "spray-can"      % "1.3.3",
-  "io.spray"               %% "spray-routing"  % "1.3.3",
-  "me.lessis"               % "semverfi_2.10"  % "0.1.3",
-  "org.apache.hadoop"       % "hadoop-common"  % "2.6.2",
-  "org.apache.hadoop"       % "hadoop-hdfs"    % "2.6.2",
-  "org.apache.spark"       %% "spark-core"     % sparkVersion.value % "provided",
-  "org.apache.spark"       %% "spark-sql"      % sparkVersion.value % "provided",
-  "org.clapper"            %% "grizzled-slf4j" % "1.0.2",
-  "org.json4s"             %% "json4s-native"  % json4sVersion.value,
-  "org.json4s"             %% "json4s-ext"     % json4sVersion.value,
-  "org.scalaj"             %% "scalaj-http"    % "1.1.6",
-  "org.spark-project.akka" %% "akka-actor"     % "2.3.4-spark",
-  "io.spray"               %% "spray-testkit"  % "1.3.3" % "test",
-  "org.specs2"             %% "specs2"         % "2.3.13" % "test",
-  "org.spark-project.akka" %% "akka-slf4j"     % "2.3.4-spark")
+  "org.apache.predictionio" %% "apache-predictionio-core" % version.value,
+  "me.lessis"                % "semverfi_2.10"  % "0.1.3",
+  "org.apache.spark"        %% "spark-sql"      % sparkVersion.value % "provided",
+  "io.spray"                %% "spray-testkit"  % "1.3.3" % "test",
+  "org.specs2"              %% "specs2"         % "2.3.13" % "test"
+)
 
-dependencyOverrides +=   "org.slf4j" % "slf4j-log4j12" % "1.7.18"
-
-assemblyMergeStrategy in assembly := {
-  case PathList("META-INF", "LICENSE.txt") => MergeStrategy.concat
-  case PathList("META-INF", "NOTICE.txt")  => MergeStrategy.concat
-  case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
-    oldStrategy(x)
-}
-
-excludedJars in assembly <<= (fullClasspath in assembly) map { cp =>
+assemblyExcludedJars in assembly <<= (fullClasspath in assembly) map { cp =>
   cp filter { _.data.getName match {
-    case "asm-3.1.jar" => true
-    case "commons-beanutils-1.7.0.jar" => true
     case "reflectasm-1.10.1.jar" => true
-    case "commons-beanutils-core-1.8.0.jar" => true
     case "kryo-3.0.3.jar" => true
-    case "slf4j-log4j12-1.7.5.jar" => true
     case _ => false
   }}
 }
@@ -68,8 +44,8 @@ assemblyShadeRules in assembly := Seq(
 // skip test in assembly
 test in assembly := {}
 
-outputPath in assembly := baseDirectory.value.getAbsoluteFile.getParentFile /
-  "assembly" / ("pio-assembly-" + version.value + ".jar")
+assemblyOutputPath in assembly := baseDirectory.value.getAbsoluteFile.getParentFile /
+  "assembly" / scalaBinaryVersion.value / s"pio-assembly-${version.value}.jar"
 
 cleanFiles <+= baseDirectory { base => base.getParentFile / "assembly" }
 

--- a/tools/src/main/scala/org/apache/predictionio/tools/Common.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/Common.scala
@@ -65,14 +65,6 @@ object Common extends EitherLogging {
     }
   }
 
-  def versionNoPatch(fullVersion: String): String = {
-    val v = """^(\d+\.\d+)""".r
-    val versionNoPatch = for {
-      v(np) <- v findFirstIn fullVersion
-    } yield np
-    versionNoPatch.getOrElse(fullVersion)
-  }
-
   def getEngineDirPath(directory: Option[String]): String = {
     new File(directory.getOrElse(".")).getCanonicalPath
   }
@@ -95,9 +87,8 @@ object Common extends EitherLogging {
     val engineDir = getEngineDirPath(Some(directory))
     val libFiles = jarFilesForScalaFilter(
       jarFilesAt(new File(engineDir, "lib")))
-    val scalaVersionNoPatch = Common.versionNoPatch(BuildInfo.scalaVersion)
     val targetFiles = jarFilesForScalaFilter(jarFilesAt(new File(engineDir,
-      "target" + File.separator + s"scala-${scalaVersionNoPatch}")))
+      "target" + File.separator + s"scala-${BuildInfo.scalaBinaryVersion}")))
     // Use libFiles is target is empty.
     if (targetFiles.size > 0) targetFiles else libFiles
   }

--- a/tools/src/main/scala/org/apache/predictionio/tools/RunServer.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/RunServer.scala
@@ -20,12 +20,10 @@ package org.apache.predictionio.tools
 
 import org.apache.predictionio.tools.Common._
 import org.apache.predictionio.tools.ReturnTypes._
-import org.apache.predictionio.workflow.WorkflowUtils
 import org.apache.predictionio.workflow.JsonExtractorOption
 import org.apache.predictionio.workflow.JsonExtractorOption.JsonExtractorOption
 
 import java.io.File
-import java.net.URI
 import grizzled.slf4j.Logging
 
 import scala.sys.process._

--- a/tools/src/main/scala/org/apache/predictionio/tools/RunWorkflow.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/RunWorkflow.scala
@@ -18,19 +18,13 @@
 package org.apache.predictionio.tools
 
 import org.apache.predictionio.tools.console.Console
-import org.apache.predictionio.tools.Runner
 import org.apache.predictionio.tools.Common._
 import org.apache.predictionio.tools.ReturnTypes._
-import org.apache.predictionio.workflow.{WorkflowUtils, JsonExtractorOption}
+import org.apache.predictionio.workflow.JsonExtractorOption
 import org.apache.predictionio.workflow.JsonExtractorOption.JsonExtractorOption
 
 import java.io.File
-import java.net.URI
 import grizzled.slf4j.Logging
-
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.FileSystem
-import org.apache.hadoop.fs.Path
 
 import scala.sys.process._
 

--- a/tools/src/main/scala/org/apache/predictionio/tools/commands/AccessKey.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/commands/AccessKey.scala
@@ -18,12 +18,8 @@
 package org.apache.predictionio.tools.commands
 
 import org.apache.predictionio.data.storage
-import org.apache.predictionio.tools
 import org.apache.predictionio.tools.EitherLogging
 import org.apache.predictionio.tools.ReturnTypes._
-
-import grizzled.slf4j.Logging
-import scala.util.Either
 
 object AccessKey extends EitherLogging {
 

--- a/tools/src/main/scala/org/apache/predictionio/tools/commands/Engine.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/commands/Engine.scala
@@ -29,13 +29,6 @@ import org.apache.predictionio.tools.ReturnTypes._
 import org.apache.predictionio.workflow.WorkflowUtils
 
 import org.apache.commons.io.FileUtils
-import org.json4s.native.Serialization.read
-import org.json4s._
-import org.json4s.native.JsonMethods._
-import org.json4s.native.Serialization.read
-import org.json4s.native.Serialization.write
-import scala.io.Source
-import scala.util.Random
 import scala.collection.JavaConversions._
 import scala.sys.process._
 import scalaj.http.Http

--- a/tools/src/main/scala/org/apache/predictionio/tools/commands/Template.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/commands/Template.scala
@@ -21,13 +21,11 @@ import java.io.File
 
 import scala.io.Source
 
-import grizzled.slf4j.Logging
 import org.apache.predictionio.core.BuildInfo
 import org.apache.predictionio.tools.EitherLogging
 import org.apache.predictionio.tools.ReturnTypes._
 import org.json4s._
 import org.json4s.native.JsonMethods._
-import org.json4s.native.Serialization.{write, read}
 import semverfi._
 
 case class TemplateMetaData(

--- a/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
@@ -22,31 +22,17 @@ import java.io.File
 import java.net.URI
 
 import grizzled.slf4j.Logging
-import org.apache.commons.io.FileUtils
-import org.apache.predictionio.controller.Utils
 import org.apache.predictionio.core.BuildInfo
-import org.apache.predictionio.data.api.{EventServer, EventServerConfig}
-import org.apache.predictionio.data.storage
-import org.apache.predictionio.tools.{RunServer, RunWorkflow, Common}
 import org.apache.predictionio.tools.commands.{
   DashboardArgs, AdminServerArgs, ImportArgs, ExportArgs,
   BuildArgs, EngineArgs}
 import org.apache.predictionio.tools.{
   EventServerArgs, SparkArgs, WorkflowArgs, ServerArgs, DeployArgs}
-import org.apache.predictionio.tools.EventServerArgs
-import org.apache.predictionio.tools.admin.{AdminServer, AdminServerConfig}
-import org.apache.predictionio.tools.dashboard.{Dashboard, DashboardConfig}
-import org.apache.predictionio.tools.commands
 import org.apache.predictionio.workflow.{JsonExtractorOption, WorkflowUtils}
-import org.apache.predictionio.workflow.JsonExtractorOption.JsonExtractorOption
 import org.json4s._
 import org.json4s.native.JsonMethods._
-import semverfi._
 
-import scala.collection.JavaConversions._
 import scala.io.Source
-import scala.sys.process._
-import scalaj.http.Http
 
 case class ConsoleArgs(
   build: BuildArgs = BuildArgs(),

--- a/tools/src/main/scala/org/apache/predictionio/tools/console/Pio.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/console/Pio.scala
@@ -19,25 +19,15 @@ package org.apache.predictionio.tools.console
 
 import org.apache.predictionio.tools.{
   EventServerArgs, SparkArgs, WorkflowArgs, ServerArgs, DeployArgs}
-import org.apache.predictionio.tools.commands.Management
 import org.apache.predictionio.tools.commands.{
   DashboardArgs, AdminServerArgs, ImportArgs, ExportArgs,
-  BuildArgs, EngineArgs, AppDescription}
-import org.apache.predictionio.tools.commands.Engine
-import org.apache.predictionio.tools.commands.{
+  BuildArgs, EngineArgs, Management, Engine, Import, Export,
   App => AppCmd, AccessKey => AccessKeysCmd}
 import org.apache.predictionio.tools.ReturnTypes._
-import org.apache.predictionio.tools.commands.Import
-import org.apache.predictionio.tools.commands.Export
 
 import grizzled.slf4j.Logging
-import scala.concurrent.{Future, ExecutionContext, Await}
-import scala.concurrent.duration._
 import scala.language.implicitConversions
 import scala.sys.process._
-import java.io.File
-
-import akka.actor.ActorSystem
 
 object Pio extends Logging {
 

--- a/tools/src/main/scala/org/apache/predictionio/tools/dashboard/CorsSupport.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/dashboard/CorsSupport.scala
@@ -22,7 +22,6 @@ package org.apache.predictionio.tools.dashboard
 
 import spray.http.{HttpMethods, HttpMethod, HttpResponse, AllOrigins}
 import spray.http.HttpHeaders._
-import spray.http.HttpMethods._
 import spray.http.HttpEntity
 import spray.routing._
 import spray.http.StatusCodes

--- a/tools/src/main/scala/org/apache/predictionio/tools/dashboard/Dashboard.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/dashboard/Dashboard.scala
@@ -23,8 +23,7 @@ import org.apache.predictionio.authentication.KeyAuthentication
 import org.apache.predictionio.configuration.SSLConfiguration
 import org.apache.predictionio.data.storage.Storage
 import spray.can.server.ServerSettings
-import spray.routing.directives.AuthMagnet
-import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.ExecutionContext
 import akka.actor.{ActorContext, Actor, ActorSystem, Props}
 import akka.io.IO
 import akka.pattern.ask
@@ -35,7 +34,6 @@ import spray.can.Http
 import spray.http._
 import spray.http.MediaTypes._
 import spray.routing._
-import spray.routing.authentication.{Authentication, UserPass, BasicAuth}
 
 import scala.concurrent.duration._
 


### PR DESCRIPTION
The goal of this PR is:
- Define the versions of Scala to build against in the crossScalaVersions setting
    - Scala 2.10 and 2.11
- At the project, run `make-distribution.sh`. Then, create all versions gzs
    - PredictionIO_2.10-0.11.0-$VERSION.tar.gz <- This is intended for Spark 1 users
    - PredictionIO_2.11-0.11.0-$VERSION.tar.gz <- This is intended for Spark 2 users
- SQLContext maintain the status quo
    - I wish support for Scala 2.10 is deprecated as of next release
- Versions of Hadoop are 2.6+, which has something to do with storage hdfs
    - 2.6 is in lib/spark(default)
    - 2.7 is in lib/extra

@chanlee514 @dszeto
I did #345.

## TODO
Currently, only the traditional version of the test works. It needs to be added new version (Spark 2) tests.