### PR TITLE
[PIO-59] Use /dev/urandom to create access keys.

### DIFF
--- a/data/src/main/scala/org/apache/predictionio/data/storage/AccessKeys.scala
+++ b/data/src/main/scala/org/apache/predictionio/data/storage/AccessKeys.scala
@@ -66,7 +66,7 @@ trait AccessKeys {
 
   /** Default implementation of key generation */
   def generateKey: String = {
-    val sr = SecureRandom.getInstanceStrong
+    val sr = new SecureRandom
     val srBytes = Array.fill(48)(0.toByte)
     sr.nextBytes(srBytes)
     Base64.encodeBase64URLSafeString(srBytes) match {


### PR DESCRIPTION
Creating access keys based on /dev/random may take a long time
on virtualized or clound environment for example more than
10 minutes.