### PR TITLE
Add parameters to specify the number of shards/replicas for elasticsearch

### DIFF
--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESAccessKeys.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESAccessKeys.scala
@@ -44,7 +44,9 @@ class ESAccessKeys(client: ESClient, config: StorageClientConfig, index: String)
 
   val restClient = client.open()
   try {
-    ESUtils.createIndex(restClient, index)
+    ESUtils.createIndex(restClient, index,
+      client.getNumberOfShards(index.toUpperCase),
+      client.getNumberOfReplicas(index.toUpperCase))
     val mappingJson =
       (estype ->
         ("_all" -> ("enabled" -> 0)) ~

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESAccessKeys.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESAccessKeys.scala
@@ -45,8 +45,8 @@ class ESAccessKeys(client: ESClient, config: StorageClientConfig, index: String)
   val restClient = client.open()
   try {
     ESUtils.createIndex(restClient, index,
-      client.getNumberOfShards(index.toUpperCase),
-      client.getNumberOfReplicas(index.toUpperCase))
+      ESUtils.getNumberOfShards(config, index.toUpperCase),
+      ESUtils.getNumberOfReplicas(config, index.toUpperCase))
     val mappingJson =
       (estype ->
         ("_all" -> ("enabled" -> 0)) ~

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESApps.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESApps.scala
@@ -46,8 +46,8 @@ class ESApps(client: ESClient, config: StorageClientConfig, index: String)
   val restClient = client.open()
   try {
     ESUtils.createIndex(restClient, index,
-      client.getNumberOfShards(index.toUpperCase),
-      client.getNumberOfReplicas(index.toUpperCase))
+      ESUtils.getNumberOfShards(config, index.toUpperCase),
+      ESUtils.getNumberOfReplicas(config, index.toUpperCase))
     val mappingJson =
       (estype ->
         ("_all" -> ("enabled" -> 0)) ~

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESApps.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESApps.scala
@@ -45,7 +45,9 @@ class ESApps(client: ESClient, config: StorageClientConfig, index: String)
 
   val restClient = client.open()
   try {
-    ESUtils.createIndex(restClient, index)
+    ESUtils.createIndex(restClient, index,
+      client.getNumberOfShards(index.toUpperCase),
+      client.getNumberOfReplicas(index.toUpperCase))
     val mappingJson =
       (estype ->
         ("_all" -> ("enabled" -> 0)) ~

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESChannels.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESChannels.scala
@@ -45,8 +45,8 @@ class ESChannels(client: ESClient, config: StorageClientConfig, index: String)
   val restClient = client.open()
   try {
     ESUtils.createIndex(restClient, index,
-      client.getNumberOfShards(index.toUpperCase),
-      client.getNumberOfReplicas(index.toUpperCase))
+      ESUtils.getNumberOfShards(config, index.toUpperCase),
+      ESUtils.getNumberOfReplicas(config, index.toUpperCase))
     val mappingJson =
       (estype ->
         ("_all" -> ("enabled" -> 0)) ~

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESChannels.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESChannels.scala
@@ -44,7 +44,9 @@ class ESChannels(client: ESClient, config: StorageClientConfig, index: String)
 
   val restClient = client.open()
   try {
-    ESUtils.createIndex(restClient, index)
+    ESUtils.createIndex(restClient, index,
+      client.getNumberOfShards(index.toUpperCase),
+      client.getNumberOfReplicas(index.toUpperCase))
     val mappingJson =
       (estype ->
         ("_all" -> ("enabled" -> 0)) ~

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESEngineInstances.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESEngineInstances.scala
@@ -45,8 +45,8 @@ class ESEngineInstances(client: ESClient, config: StorageClientConfig, index: St
   val restClient = client.open()
   try {
     ESUtils.createIndex(restClient, index,
-      client.getNumberOfShards(index.toUpperCase),
-      client.getNumberOfReplicas(index.toUpperCase))
+      ESUtils.getNumberOfShards(config, index.toUpperCase),
+      ESUtils.getNumberOfReplicas(config, index.toUpperCase))
     val mappingJson =
       (estype ->
         ("_all" -> ("enabled" -> 0)) ~

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESEngineInstances.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESEngineInstances.scala
@@ -44,7 +44,9 @@ class ESEngineInstances(client: ESClient, config: StorageClientConfig, index: St
 
   val restClient = client.open()
   try {
-    ESUtils.createIndex(restClient, index)
+    ESUtils.createIndex(restClient, index,
+      client.getNumberOfShards(index.toUpperCase),
+      client.getNumberOfReplicas(index.toUpperCase))
     val mappingJson =
       (estype ->
         ("_all" -> ("enabled" -> 0)) ~

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESEvaluationInstances.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESEvaluationInstances.scala
@@ -46,7 +46,9 @@ class ESEvaluationInstances(client: ESClient, config: StorageClientConfig, index
 
   val restClient = client.open()
   try {
-    ESUtils.createIndex(restClient, index)
+    ESUtils.createIndex(restClient, index,
+      client.getNumberOfShards(index.toUpperCase),
+      client.getNumberOfReplicas(index.toUpperCase))
     val mappingJson =
       (estype ->
         ("_all" -> ("enabled" -> 0)) ~

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESEvaluationInstances.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESEvaluationInstances.scala
@@ -47,8 +47,8 @@ class ESEvaluationInstances(client: ESClient, config: StorageClientConfig, index
   val restClient = client.open()
   try {
     ESUtils.createIndex(restClient, index,
-      client.getNumberOfShards(index.toUpperCase),
-      client.getNumberOfReplicas(index.toUpperCase))
+      ESUtils.getNumberOfShards(config, index.toUpperCase),
+      ESUtils.getNumberOfReplicas(config, index.toUpperCase))
     val mappingJson =
       (estype ->
         ("_all" -> ("enabled" -> 0)) ~

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESLEvents.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESLEvents.scala
@@ -60,7 +60,9 @@ class ESLEvents(val client: ESClient, config: StorageClientConfig, val index: St
     val estype = getEsType(appId, channelId)
     val restClient = client.open()
     try {
-      ESUtils.createIndex(restClient, index)
+      ESUtils.createIndex(restClient, index,
+        client.getNumberOfShards(index.toUpperCase),
+        client.getNumberOfReplicas(index.toUpperCase))
       val json =
         (estype ->
           ("_all" -> ("enabled" -> 0)) ~

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESLEvents.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESLEvents.scala
@@ -61,8 +61,8 @@ class ESLEvents(val client: ESClient, config: StorageClientConfig, val index: St
     val restClient = client.open()
     try {
       ESUtils.createIndex(restClient, index,
-        client.getNumberOfShards(index.toUpperCase),
-        client.getNumberOfReplicas(index.toUpperCase))
+        ESUtils.getNumberOfShards(config, index.toUpperCase),
+        ESUtils.getNumberOfReplicas(config, index.toUpperCase))
       val json =
         (estype ->
           ("_all" -> ("enabled" -> 0)) ~

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESSequences.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESSequences.scala
@@ -41,7 +41,9 @@ class ESSequences(client: ESClient, config: StorageClientConfig, index: String) 
 
   val restClient = client.open()
   try {
-    ESUtils.createIndex(restClient, index)
+    ESUtils.createIndex(restClient, index,
+      client.getNumberOfShards(index.toUpperCase),
+      client.getNumberOfReplicas(index.toUpperCase))
     val mappingJson =
       (estype ->
         ("_all" -> ("enabled" -> 0)))

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESSequences.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESSequences.scala
@@ -42,8 +42,8 @@ class ESSequences(client: ESClient, config: StorageClientConfig, index: String) 
   val restClient = client.open()
   try {
     ESUtils.createIndex(restClient, index,
-      client.getNumberOfShards(index.toUpperCase),
-      client.getNumberOfReplicas(index.toUpperCase))
+      ESUtils.getNumberOfShards(config, index.toUpperCase),
+      ESUtils.getNumberOfReplicas(config, index.toUpperCase))
     val mappingJson =
       (estype ->
         ("_all" -> ("enabled" -> 0)))

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESUtils.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESUtils.scala
@@ -269,4 +269,12 @@ object ESUtils {
       map(_.split(",").toSeq).getOrElse(Seq("http"))
     (hosts, ports, schemes).zipped.map((h, p, s) => new HttpHost(h, p, s))
   }
+
+  def getNumberOfShards(config: StorageClientConfig, index: String): Option[Int] = {
+    config.properties.get(s"${index}_NUM_OF_SHARDS").map(_.toInt)
+  }
+
+  def getNumberOfReplicas(config: StorageClientConfig, index: String): Option[Int] = {
+    config.properties.get(s"${index}_NUM_OF_REPLICAS").map(_.toInt)
+  }
 }

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESUtils.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESUtils.scala
@@ -166,16 +166,23 @@ object ESUtils {
 
   def createIndex(
     client: RestClient,
-    index: String): Unit = {
+    index: String,
+    numberOfShards: Option[Int],
+    numberOfReplicas: Option[Int]): Unit = {
     client.performRequest(
       "HEAD",
       s"/$index",
       Map.empty[String, String].asJava).getStatusLine.getStatusCode match {
         case 404 =>
+          val json = ("settings" ->
+            ("number_of_shards" -> numberOfShards) ~
+            ("number_of_replicas" -> numberOfReplicas))
+          val entity = new NStringEntity(compact(render(json)), ContentType.APPLICATION_JSON)
           client.performRequest(
             "PUT",
             s"/$index",
-            Map.empty[String, String].asJava)
+            Map.empty[String, String].asJava,
+            entity)
         case 200 =>
         case _ =>
           throw new IllegalStateException(s"/$index is invalid.")

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/StorageClient.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/StorageClient.scala
@@ -25,7 +25,7 @@ import org.elasticsearch.client.RestClient
 
 import grizzled.slf4j.Logging
 
-case class ESClient(hosts: Seq[HttpHost], config: StorageClientConfig) {
+case class ESClient(hosts: Seq[HttpHost]) {
   def open(): RestClient = {
     try {
       RestClient.builder(hosts: _*).build()
@@ -34,19 +34,11 @@ case class ESClient(hosts: Seq[HttpHost], config: StorageClientConfig) {
         throw new StorageClientException(e.getMessage, e)
     }
   }
-
-  def getNumberOfShards(index: String): Option[Int] = {
-    config.properties.get(s"${index}_NUM_OF_SHARDS").map(_.toInt)
-  }
-
-  def getNumberOfReplicas(index: String): Option[Int] = {
-    config.properties.get(s"${index}_NUM_OF_REPLICAS").map(_.toInt)
-  }
 }
 
 class StorageClient(val config: StorageClientConfig) extends BaseStorageClient
     with Logging {
   override val prefix = "ES"
 
-  val client = ESClient(ESUtils.getHttpHosts(config), config)
+  val client = ESClient(ESUtils.getHttpHosts(config))
 }

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/StorageClient.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/StorageClient.scala
@@ -25,7 +25,7 @@ import org.elasticsearch.client.RestClient
 
 import grizzled.slf4j.Logging
 
-case class ESClient(hosts: Seq[HttpHost]) {
+case class ESClient(hosts: Seq[HttpHost], config: StorageClientConfig) {
   def open(): RestClient = {
     try {
       RestClient.builder(hosts: _*).build()
@@ -34,11 +34,19 @@ case class ESClient(hosts: Seq[HttpHost]) {
         throw new StorageClientException(e.getMessage, e)
     }
   }
+
+  def getNumberOfShards(index: String): Option[Int] = {
+    config.properties.get(s"${index}_NUM_OF_SHARDS").map(_.toInt)
+  }
+
+  def getNumberOfReplicas(index: String): Option[Int] = {
+    config.properties.get(s"${index}_NUM_OF_REPLICAS").map(_.toInt)
+  }
 }
 
 class StorageClient(val config: StorageClientConfig) extends BaseStorageClient
     with Logging {
   override val prefix = "ES"
 
-  val client = ESClient(ESUtils.getHttpHosts(config))
+  val client = ESClient(ESUtils.getHttpHosts(config), config)
 }


### PR DESCRIPTION
To set the number of shards/replicas, add the following values:
- PIO_STORAGE_SOURCES_ELASTICSEARCH_${INDEX}_NUM_OF_SHARDS
- PIO_STORAGE_SOURCES_ELASTICSEARCH_${INDEX}_NUM_OF_REPLICAS

For examples, they are in pio-env.sh:
```
PIO_STORAGE_SOURCES_ELASTICSEARCH_PIO_META_NUM_OF_SHARDS=1
PIO_STORAGE_SOURCES_ELASTICSEARCH_PIO_META_NUM_OF_REPLICAS=2
PIO_STORAGE_SOURCES_ELASTICSEARCH_PIO_EVENT_NUM_OF_SHARDS=10
PIO_STORAGE_SOURCES_ELASTICSEARCH_PIO_EVENT_NUM_OF_REPLICAS=1
```