### PR TITLE
Add EVENTDATA_REFRESH for elasticsearch

### DIFF
--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESLEvents.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESLEvents.scala
@@ -95,7 +95,7 @@ class ESLEvents(val client: ESClient, config: StorageClientConfig, val index: St
       restClient.performRequest(
         "POST",
         s"/$index/$estype/_delete_by_query",
-        Map("refresh" -> client.getEventDataRefresh()).asJava,
+        Map("refresh" -> ESUtils.getEventDataRefresh(config)).asJava,
         entity).getStatusLine.getStatusCode match {
           case 200 => true
           case _ =>
@@ -144,7 +144,7 @@ class ESLEvents(val client: ESClient, config: StorageClientConfig, val index: St
         val response = restClient.performRequest(
           "POST",
           s"/$index/$estype/$id",
-          Map("refresh" -> client.getEventDataRefresh()).asJava,
+          Map("refresh" -> ESUtils.getEventDataRefresh(config)).asJava,
           entity)
         val jsonResponse = parse(EntityUtils.toString(response.getEntity))
         val result = (jsonResponse \ "result").extract[String]
@@ -240,7 +240,7 @@ class ESLEvents(val client: ESClient, config: StorageClientConfig, val index: St
         val response = restClient.performRequest(
           "POST",
           s"/$index/$estype/_delete_by_query",
-          Map("refresh" -> client.getEventDataRefresh()).asJava)
+          Map("refresh" -> ESUtils.getEventDataRefresh(config)).asJava)
         val jsonResponse = parse(EntityUtils.toString(response.getEntity))
         val result = (jsonResponse \ "result").extract[String]
         result match {

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESLEvents.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESLEvents.scala
@@ -95,7 +95,7 @@ class ESLEvents(val client: ESClient, config: StorageClientConfig, val index: St
       restClient.performRequest(
         "POST",
         s"/$index/$estype/_delete_by_query",
-        Map("refresh" -> "true").asJava,
+        Map("refresh" -> client.getEventDataRefresh()).asJava,
         entity).getStatusLine.getStatusCode match {
           case 200 => true
           case _ =>
@@ -144,7 +144,7 @@ class ESLEvents(val client: ESClient, config: StorageClientConfig, val index: St
         val response = restClient.performRequest(
           "POST",
           s"/$index/$estype/$id",
-          Map("refresh" -> "true").asJava,
+          Map("refresh" -> client.getEventDataRefresh()).asJava,
           entity)
         val jsonResponse = parse(EntityUtils.toString(response.getEntity))
         val result = (jsonResponse \ "result").extract[String]
@@ -240,7 +240,7 @@ class ESLEvents(val client: ESClient, config: StorageClientConfig, val index: St
         val response = restClient.performRequest(
           "POST",
           s"/$index/$estype/_delete_by_query",
-          Map("refresh" -> "true").asJava)
+          Map("refresh" -> client.getEventDataRefresh()).asJava)
         val jsonResponse = parse(EntityUtils.toString(response.getEntity))
         val result = (jsonResponse \ "result").extract[String]
         result match {

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESPEvents.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESPEvents.scala
@@ -120,7 +120,7 @@ class ESPEvents(client: ESClient, config: StorageClientConfig, index: String)
             val response = restClient.performRequest(
               "POST",
               s"/$index/$estype/_delete_by_query",
-              Map("refresh" -> client.getEventDataRefresh()).asJava)
+              Map("refresh" -> ESUtils.getEventDataRefresh(config)).asJava)
             val jsonResponse = parse(EntityUtils.toString(response.getEntity))
             val result = (jsonResponse \ "result").extract[String]
             result match {

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESPEvents.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESPEvents.scala
@@ -120,7 +120,7 @@ class ESPEvents(client: ESClient, config: StorageClientConfig, index: String)
             val response = restClient.performRequest(
               "POST",
               s"/$index/$estype/_delete_by_query",
-              Map("refresh" -> "true").asJava)
+              Map("refresh" -> client.getEventDataRefresh()).asJava)
             val jsonResponse = parse(EntityUtils.toString(response.getEntity))
             val result = (jsonResponse \ "result").extract[String]
             result match {

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESUtils.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESUtils.scala
@@ -262,4 +262,8 @@ object ESUtils {
       map(_.split(",").toSeq).getOrElse(Seq("http"))
     (hosts, ports, schemes).zipped.map((h, p, s) => new HttpHost(h, p, s))
   }
+
+  def getEventDataRefresh(config: StorageClientConfig): String = {
+    config.properties.getOrElse("EVENTDATA_REFRESH", "true")
+  }
 }

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/StorageClient.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/StorageClient.scala
@@ -25,7 +25,7 @@ import org.elasticsearch.client.RestClient
 
 import grizzled.slf4j.Logging
 
-case class ESClient(hosts: Seq[HttpHost], config: StorageClientConfig) {
+case class ESClient(hosts: Seq[HttpHost]) {
   def open(): RestClient = {
     try {
       RestClient.builder(hosts: _*).build()
@@ -34,15 +34,11 @@ case class ESClient(hosts: Seq[HttpHost], config: StorageClientConfig) {
         throw new StorageClientException(e.getMessage, e)
     }
   }
-
-  def getEventDataRefresh(): String = {
-    config.properties.getOrElse("EVENTDATA_REFRESH", "true")
-  }
 }
 
 class StorageClient(val config: StorageClientConfig) extends BaseStorageClient
     with Logging {
   override val prefix = "ES"
 
-  val client = ESClient(ESUtils.getHttpHosts(config), config)
+  val client = ESClient(ESUtils.getHttpHosts(config))
 }

--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/StorageClient.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/StorageClient.scala
@@ -25,7 +25,7 @@ import org.elasticsearch.client.RestClient
 
 import grizzled.slf4j.Logging
 
-case class ESClient(hosts: Seq[HttpHost]) {
+case class ESClient(hosts: Seq[HttpHost], config: StorageClientConfig) {
   def open(): RestClient = {
     try {
       RestClient.builder(hosts: _*).build()
@@ -34,11 +34,15 @@ case class ESClient(hosts: Seq[HttpHost]) {
         throw new StorageClientException(e.getMessage, e)
     }
   }
+
+  def getEventDataRefresh(): String = {
+    config.properties.getOrElse("EVENTDATA_REFRESH", "true")
+  }
 }
 
 class StorageClient(val config: StorageClientConfig) extends BaseStorageClient
     with Logging {
   override val prefix = "ES"
 
-  val client = ESClient(ESUtils.getHttpHosts(config))
+  val client = ESClient(ESUtils.getHttpHosts(config), config)
 }


### PR DESCRIPTION
To improve indexing performance for event data, it's better to be able to set refresh parameter.
In PIO, refresh is true by default because updated data need to be made visible immediately.
To disable refresh on indexing actions, in this fix, set it as below:

    PIO_STORAGE_SOURCES_ELASTICSEARCH_EVENTDATA_REFRESH=false

