### PR TITLE
Fix sbt warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ hadoopVersion in ThisBuild := sys.props.getOrElse(
   scalaSparkDepsVersion(scalaBinaryVersion.value)(sparkBinaryVersion.value)("hadoop"))
 
 val pioBuildInfoSettings = buildInfoSettings ++ Seq(
-  sourceGenerators in Compile <+= buildInfo,
+  sourceGenerators in Compile += buildInfo,
   buildInfoKeys := Seq[BuildInfoKey](
     name,
     version,

--- a/tools/build.sbt
+++ b/tools/build.sbt
@@ -35,7 +35,8 @@ assemblyMergeStrategy in assembly := {
     oldStrategy(x)
 }
 
-assemblyExcludedJars in assembly <<= (fullClasspath in assembly) map { cp =>
+assemblyExcludedJars in assembly := {
+  val cp = (fullClasspath in assembly).value
   cp filter { _.data.getName match {
     case "reflectasm-1.10.1.jar" => true
     case "kryo-3.0.3.jar" => true
@@ -55,7 +56,7 @@ test in assembly := {}
 assemblyOutputPath in assembly := baseDirectory.value.getAbsoluteFile.getParentFile /
   "assembly" / "src" / "universal" / "lib" / s"pio-assembly-${version.value}.jar"
 
-cleanFiles <+= baseDirectory { base => base.getParentFile /
-  "assembly" / "src" / "universal" / "lib" }
+cleanFiles += baseDirectory.value.getParentFile /
+  "assembly" / "src" / "universal" / "lib" 
 
 pomExtra := childrenPomExtra.value


### PR DESCRIPTION
Some operators are deprecated since sbt 0.13.13, so current sbt configuration causes following warnings. This pull request fix them.
```
[info] Compiling 1 Scala source to /Users/takezoe/Downloads/apache-predictionio-0.11.0-incubating/apache-predictionio-0.11.0-incubating/project/target/scala-2.10/sbt-0.13/classes...
/Users/takezoe/Downloads/apache-predictionio-0.11.0-incubating/apache-predictionio-0.11.0-incubating/build.sbt:86: warning: `<+=` operator is deprecated. Use `lhs += { x.value }`.
  sourceGenerators in Compile <+= buildInfo,
                              ^
/Users/takezoe/Downloads/apache-predictionio-0.11.0-incubating/apache-predictionio-0.11.0-incubating/tools/build.sbt:38: warning: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
assemblyExcludedJars in assembly <<= (fullClasspath in assembly) map { cp =>
                                 ^
/Users/takezoe/Downloads/apache-predictionio-0.11.0-incubating/apache-predictionio-0.11.0-incubating/tools/build.sbt:58: warning: `<+=` operator is deprecated. Use `lhs += { x.value }`.
cleanFiles <+= baseDirectory { base => base.getParentFile /
           ^
[info] Set current project to apache-predictionio-parent (in build file:/Users/takezoe/Downloads/apache-predictionio-0.11.0-incubating/apache-predictionio-0.11.0-incubating/)
```