### PR TITLE
[PIO-65] Cache downloaded jars in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,11 @@ services:
 
 sudo: required
 
-cache: false
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot
+    - $HOME/.sbt/launchers
 
 env:
   matrix:


### PR DESCRIPTION
Sometimes Travis build fails in downloading jars. Maybe caching them makes Travis build stable and also decreases build time.