### PR TITLE
[PIO-91] Fixed hadoop-hdfs artifact missing error

### DIFF
--- a/storage/hdfs/build.sbt
+++ b/storage/hdfs/build.sbt
@@ -22,6 +22,7 @@ name := "apache-predictionio-data-hdfs"
 libraryDependencies ++= Seq(
   "org.apache.hadoop"        % "hadoop-common"            % hadoopVersion.value
     exclude("commons-beanutils", "*"),
+  "org.apache.hadoop"        % "hadoop-hdfs"              % hadoopVersion.value,
   "org.apache.predictionio" %% "apache-predictionio-data" % version.value % "provided",
   "org.scalatest"           %% "scalatest"                % "2.1.7" % "test")
 


### PR DESCRIPTION
I made a mistake when I reviewed dependencies.
Basically, the problem is due to unavailability of the hadoop-hdfs jars.