### PR TITLE
Fix duplicate org name

### DIFF
--- a/docs/manual/source/partials/shared/quickstart/_create_engine.html.md.erb
+++ b/docs/manual/source/partials/shared/quickstart/_create_engine.html.md.erb
@@ -18,7 +18,7 @@ limitations under the License.
 Now let's create a new engine called *<%= engine_name %>* by downloading the <%= template_name %>. Go to a directory where you want to put your engine and run the following:
 
 ```
-$ git clone https://github.com/apache/<%= template_repo %>.git <%= engine_name %>
+$ git clone https://github.com/<%= template_repo %>.git <%= engine_name %>
 $ cd <%= engine_name %>
 ```
 


### PR DESCRIPTION

<img width="894" alt="screen shot 2017-06-05 at 13 51 45" src="https://cloud.githubusercontent.com/assets/222101/26783428/611434f8-49f8-11e7-9b5b-2d4f2dd656be.png">


template repo in all the cases where this is used is passed in as a github slug "org/repo" and ends up having broken links with duplicate org in them.
https://github.com/apache/incubator-predictionio/blob/livedoc/docs/manual/source/templates/vanilla/quickstart.html.md.erb#L49