### PR TITLE
[PIO-94] Fix to show stacktrace for errors thrown in `queries.json` REST API

### DIFF
--- a/core/src/main/scala/org/apache/predictionio/workflow/CreateServer.scala
+++ b/core/src/main/scala/org/apache/predictionio/workflow/CreateServer.scala
@@ -594,14 +594,14 @@ class ServerActor[Q, P](
               }
             } catch {
               case e: MappingException =>
-                log.error(
-                  s"Query '$queryString' is invalid. Reason: ${e.getMessage}")
+                val msg = s"Query:\n$queryString\n\nStack Trace:\n" +
+                  s"${getStackTraceString(e)}\n\n"
+                log.error(msg)
                 args.logUrl map { url =>
                   remoteLog(
                     url,
                     args.logPrefix.getOrElse(""),
-                    s"Query:\n$queryString\n\nStack Trace:\n" +
-                      s"${getStackTraceString(e)}\n\n")
+                    msg)
                   }
                 complete(StatusCodes.BadRequest, e.getMessage)
               case e: Throwable =>


### PR DESCRIPTION
We were getting intractable errors from `queries.json` requests, like this one without a stacktrace:

```
[ERROR] [ServerActor] Query '{
  "user": "000",
  "item": "000"
}' is invalid. Reason: Expected object but got JNothing
```

This pull request adds stacktraces to these errors using the pattern already present elsewhere in `CreateServer.scala`.

[JIRA issue](https://issues.apache.org/jira/browse/PIO-94)