### PR TITLE
[PIO-95] Extend request timeout for REST API

### DIFF
--- a/common/src/main/resources/application.conf
+++ b/common/src/main/resources/application.conf
@@ -7,5 +7,6 @@ akka {
 spray.can {
   server {
     verbose-error-messages = "on"
+    request-timeout = 35s
   }
 }


### PR DESCRIPTION
We've found the default 20-second REST API request timeout is too short for our batch-prediction use cases. We're running PredictionIO on Heroku which has its own [timeout starting at 30-seonds](https://devcenter.heroku.com/articles/limits#http-timeouts). So we'd prefer a more generous or easily configurable timeout to allow Heroku's routing layer to impose & track this limit in the platform layer.

I investigated how to configure this and found [Spray `application.conf`](http://spray.io/documentation/1.2.4/spray-can/configuration/). This PR simply increases the timeout.

I would love guidance on how we might extract this config into an environment variable or a value in `pio-env.sh`.

[JIRA issue](https://issues.apache.org/jira/browse/PIO-95)