### PR TITLE
[PIO-92] Bump HBase to 1.2.6

### DIFF
--- a/storage/hbase/build.sbt
+++ b/storage/hbase/build.sbt
@@ -22,11 +22,11 @@ name := "apache-predictionio-data-hbase"
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % version.value % "provided",
   "org.apache.spark"        %% "spark-core"     % sparkVersion.value % "provided",
-  "org.apache.hbase"         % "hbase-common"   % "0.98.5-hadoop2",
-  "org.apache.hbase"         % "hbase-client"   % "0.98.5-hadoop2"
+  "org.apache.hbase"         % "hbase-common"   % "1.2.6",
+  "org.apache.hbase"         % "hbase-client"   % "1.2.6"
     exclude("org.apache.zookeeper", "zookeeper"),
   // added for Parallel storage interface
-  "org.apache.hbase"         % "hbase-server"   % "0.98.5-hadoop2"
+  "org.apache.hbase"         % "hbase-server"   % "1.2.6"
     exclude("org.apache.hbase", "hbase-client")
     exclude("org.apache.zookeeper", "zookeeper")
     exclude("javax.servlet", "servlet-api")


### PR DESCRIPTION
This request upgrade only HBase dependency. Some methods have been deprecated, but they are not fixed in this request for backward compatibility.