### PR TITLE
[PIO-69] Add sbt-dependency-graph plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import com.typesafe.sbt.license.{LicenseInfo, DepModuleInfo}
 import PIOBuild._
 
 lazy val scalaSparkDepsVersion = Map(
@@ -98,6 +98,7 @@ val conf = file("conf")
 
 val commonSettings = Seq(
   autoAPIMappings := true,
+  licenseConfigurations := Set("compile"),
   unmanagedClasspath in Test += conf,
   unmanagedClasspath in Test += baseDirectory.value.getParentFile / s"storage/jdbc/target/scala-${scalaBinaryVersion.value}/classes")
 

--- a/make-licensereport.sh
+++ b/make-licensereport.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FWDIR="$(cd `dirname $0`; pwd)"
+cd ${FWDIR}
+set -x
+
+sbt/sbt clean
+sbt/sbt dumpLicenseReport
+
+sbt/sbt storage/clean
+sbt/sbt storage/dumpLicenseReport
+
+rm -rf license-reports
+mkdir license-reports
+
+find . -name "*-licenses.csv" -exec cat {} >> license-reports/licences-concat.csv \;
+cat license-reports/licences-concat.csv | sort | uniq | grep -v Apache | grep -v ASL | grep -v predictionio > license-reports/licences-notice.csv

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositori
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0-M8")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")


### PR DESCRIPTION
Add [sbt-dependency-graph plugin](https://github.com/jrudolph/sbt-dependency-graph) to inspect license of depended libraries.

We can run inspection as:

```
sbt dependencyLicenseInfo
```

Result in the latest develop branch:

```
[info] No license specified
[info]   org.apache.predictionio:apache-predictionio-common_2.10:0.11.1-SNAPSHOT
[info] 
[info] Apache 2
[info]   io.spray:spray-routing_2.10:1.3.3
[info]   io.spray:spray-httpx_2.10:1.3.3
[info]   io.spray:spray-can_2.10:1.3.3
[info]   io.spray:spray-io_2.10:1.3.3
[info]   io.spray:spray-http_2.10:1.3.3
[info]   org.parboiled:parboiled-scala_2.10:1.1.7
[info]   org.parboiled:parboiled-core:1.1.7
[info]   io.spray:spray-util_2.10:1.3.3
[info] 
[info] Apache License
[info]   com.chuusai:shapeless_2.10:1.2.4
[info] 
[info] Apache License, Version 2.0
[info]   com.typesafe.akka:akka-slf4j_2.10:2.3.15
[info]   com.typesafe.akka:akka-actor_2.10:2.3.15
[info]   com.typesafe:config:1.2.1
[info] 
[info] CDDL 1.1
[info]   org.jvnet.mimepull:mimepull:1.9.5
[info] 
[info] MIT License
[info]   org.slf4j:slf4j-api:1.7.5
[info] No license specified
[info]   org.apache.predictionio:apache-predictionio-parent_2.10:0.11.1-SNAPSHOT
[info] No license specified
[info]   org.apache.predictionio:apache-predictionio-e2_2.10:0.11.1-SNAPSHOT
[info] Updating {file:/Users/naoki.takezoe/incubator-predictionio/}data...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] Updating {file:/Users/naoki.takezoe/incubator-predictionio/}data...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] No license specified
[info]   org.apache.predictionio:apache-predictionio-data_2.10:0.11.1-SNAPSHOT
[info]   org.apache.predictionio:apache-predictionio-common_2.10:0.11.1-SNAPSHOT
[info] 
[info] ASL
[info]   org.json4s:json4s-native_2.10:3.2.10
[info]   org.json4s:json4s-core_2.10:3.2.10
[info]   org.json4s:json4s-ast_2.10:3.2.10
[info] 
[info] Apache
[info]   com.github.nscala-time:nscala-time_2.10:2.6.0
[info] 
[info] Apache 2
[info]   joda-time:joda-time:2.9.1
[info]   org.joda:joda-convert:1.2
[info]   io.spray:spray-routing_2.10:1.3.3
[info]   io.spray:spray-httpx_2.10:1.3.3
[info]   io.spray:spray-can_2.10:1.3.3
[info]   io.spray:spray-io_2.10:1.3.3
[info]   io.spray:spray-http_2.10:1.3.3
[info]   org.parboiled:parboiled-scala_2.10:1.1.7
[info]   org.parboiled:parboiled-core:1.1.7
[info]   io.spray:spray-util_2.10:1.3.3
[info] 
[info] Apache License
[info]   com.chuusai:shapeless_2.10:1.2.4
[info] 
[info] Apache License, Version 2.0
[info]   com.typesafe.akka:akka-slf4j_2.10:2.3.15
[info]   com.typesafe.akka:akka-actor_2.10:2.3.15
[info]   com.typesafe:config:1.2.1
[info] 
[info] BSD
[info]   com.thoughtworks.paranamer:paranamer:2.6
[info]   org.clapper:grizzled-slf4j_2.10:1.0.2
[info] 
[info] BSD-like
[info]   org.scala-lang:scalap:2.10.6
[info]   org.scala-lang:scala-compiler:2.10.6
[info]   org.scala-lang:scala-reflect:2.10.6
[info] 
[info] CDDL 1.1
[info]   org.jvnet.mimepull:mimepull:1.9.5
[info] 
[info] MIT License
[info]   org.slf4j:slf4j-api:1.7.7
[info] Updating {file:/Users/naoki.takezoe/incubator-predictionio/}core...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] Updating {file:/Users/naoki.takezoe/incubator-predictionio/}core...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] No license specified
[info]   org.apache.predictionio:apache-predictionio-core_2.10:0.11.1-SNAPSHOT
[info]   org.apache.predictionio:apache-predictionio-data_2.10:0.11.1-SNAPSHOT
[info]   org.apache.predictionio:apache-predictionio-common_2.10:0.11.1-SNAPSHOT
[info] 
[info] ASL
[info]   org.json4s:json4s-ext_2.10:3.2.10
[info]   org.json4s:json4s-native_2.10:3.2.10
[info]   org.json4s:json4s-core_2.10:3.2.10
[info]   org.json4s:json4s-ast_2.10:3.2.10
[info] 
[info] Apache
[info]   com.github.nscala-time:nscala-time_2.10:2.6.0
[info] 
[info] Apache 2
[info]   org.scalaj:scalaj-http_2.10:1.1.6
[info]   org.joda:joda-convert:1.6
[info]   org.objenesis:objenesis:2.1
[info]   com.twitter:chill-bijection_2.10:0.7.2
[info]   com.twitter:bijection-core_2.10:0.8.0
[info]   com.twitter:chill_2.10:0.7.2
[info]   com.twitter:chill-java:0.7.2
[info]   joda-time:joda-time:2.9.1
[info]   io.spray:spray-routing_2.10:1.3.3
[info]   io.spray:spray-httpx_2.10:1.3.3
[info]   io.spray:spray-can_2.10:1.3.3
[info]   io.spray:spray-io_2.10:1.3.3
[info]   io.spray:spray-http_2.10:1.3.3
[info]   org.parboiled:parboiled-scala_2.10:1.1.7
[info]   org.parboiled:parboiled-core:1.1.7
[info]   io.spray:spray-util_2.10:1.3.3
[info] 
[info] Apache License
[info]   com.chuusai:shapeless_2.10:1.2.4
[info] 
[info] Apache License, Version 2.0
[info]   net.jodah:typetools:0.3.1
[info]   org.apache.commons:commons-lang3:3.4
[info]   com.typesafe.akka:akka-slf4j_2.10:2.3.15
[info]   com.typesafe.akka:akka-actor_2.10:2.3.15
[info]   com.typesafe:config:1.2.1
[info] 
[info] Apache-2.0
[info]   com.typesafe.play:twirl-api_2.10:1.1.1
[info] 
[info] BSD
[info]   org.ow2.asm:asm:5.0.3
[info]   com.thoughtworks.paranamer:paranamer:2.6
[info]   org.clapper:grizzled-slf4j_2.10:1.0.2
[info] 
[info] BSD-like
[info]   org.scala-lang:scalap:2.10.6
[info]   org.scala-lang:scala-compiler:2.10.6
[info]   org.scala-lang:scala-reflect:2.10.6
[info] 
[info] CDDL 1.1
[info]   org.jvnet.mimepull:mimepull:1.9.5
[info] 
[info] MIT License
[info]   org.slf4j:slf4j-log4j12:1.7.18
[info]   org.slf4j:slf4j-api:1.7.18
[info]   com.github.scopt:scopt_2.10:3.5.0
[info] 
[info] New BSD License
[info]   com.esotericsoftware:kryo:3.0.3
[info]   com.esotericsoftware:minlog:1.3.0
[info]   com.esotericsoftware:reflectasm:1.10.1
[info]   com.esotericsoftware.kryo:kryo:2.21
[info]   com.esotericsoftware.minlog:minlog:1.2
[info]   com.esotericsoftware.reflectasm:reflectasm:1.07
[info] 
[info] New BSD license
[info]   com.google.protobuf:protobuf-java:2.6.1
[info] 
[info] The Apache Software License, Version 2.0
[info]   log4j:log4j:1.2.17
[info]   de.javakaffee:kryo-serializers:0.37
[info]   com.google.code.gson:gson:2.5
[info] Updating {file:/Users/naoki.takezoe/incubator-predictionio/}tools...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] No license specified
[info]   org.apache.predictionio:apache-predictionio-tools_2.10:0.11.1-SNAPSHOT
[info]   org.apache.predictionio:apache-predictionio-core_2.10:0.11.1-SNAPSHOT
[info]   org.apache.predictionio:apache-predictionio-data_2.10:0.11.1-SNAPSHOT
[info]   org.apache.predictionio:apache-predictionio-common_2.10:0.11.1-SNAPSHOT
[info] 
[info] ASL
[info]   org.json4s:json4s-ext_2.10:3.2.10
[info]   org.json4s:json4s-native_2.10:3.2.10
[info]   org.json4s:json4s-core_2.10:3.2.10
[info]   org.json4s:json4s-ast_2.10:3.2.10
[info] 
[info] Apache
[info]   com.github.nscala-time:nscala-time_2.10:2.6.0
[info] 
[info] Apache 2
[info]   org.scalaj:scalaj-http_2.10:1.1.6
[info]   org.joda:joda-convert:1.6
[info]   org.objenesis:objenesis:2.1
[info]   com.twitter:chill-bijection_2.10:0.7.2
[info]   com.twitter:bijection-core_2.10:0.8.0
[info]   com.twitter:chill_2.10:0.7.2
[info]   com.twitter:chill-java:0.7.2
[info]   joda-time:joda-time:2.9.1
[info]   io.spray:spray-routing_2.10:1.3.3
[info]   io.spray:spray-httpx_2.10:1.3.3
[info]   io.spray:spray-can_2.10:1.3.3
[info]   io.spray:spray-io_2.10:1.3.3
[info]   io.spray:spray-http_2.10:1.3.3
[info]   org.parboiled:parboiled-scala_2.10:1.1.7
[info]   org.parboiled:parboiled-core:1.1.7
[info]   io.spray:spray-util_2.10:1.3.3
[info] 
[info] Apache License
[info]   com.chuusai:shapeless_2.10:1.2.4
[info] 
[info] Apache License, Version 2.0
[info]   net.jodah:typetools:0.3.1
[info]   org.apache.commons:commons-lang3:3.4
[info]   com.typesafe.akka:akka-slf4j_2.10:2.3.15
[info]   com.typesafe.akka:akka-actor_2.10:2.3.15
[info]   com.typesafe:config:1.2.1
[info] 
[info] Apache-2.0
[info]   com.typesafe.play:twirl-api_2.10:1.1.1
[info] 
[info] BSD
[info]   org.ow2.asm:asm:5.0.3
[info]   com.thoughtworks.paranamer:paranamer:2.6
[info]   org.clapper:grizzled-slf4j_2.10:1.0.2
[info] 
[info] BSD-like
[info]   org.scala-lang:scalap:2.10.6
[info]   org.scala-lang:scala-compiler:2.10.6
[info]   org.scala-lang:scala-reflect:2.10.6
[info] 
[info] CDDL 1.1
[info]   org.jvnet.mimepull:mimepull:1.9.5
[info] 
[info] MIT
[info]   me.lessis:semverfi_2.10:0.1.3
[info] 
[info] MIT License
[info]   org.slf4j:slf4j-log4j12:1.7.18
[info]   org.slf4j:slf4j-api:1.7.18
[info]   com.github.scopt:scopt_2.10:3.5.0
[info] 
[info] New BSD License
[info]   com.esotericsoftware:kryo:3.0.3
[info]   com.esotericsoftware:minlog:1.3.0
[info]   com.esotericsoftware:reflectasm:1.10.1
[info]   com.esotericsoftware.kryo:kryo:2.21
[info]   com.esotericsoftware.minlog:minlog:1.2
[info]   com.esotericsoftware.reflectasm:reflectasm:1.07
[info] 
[info] New BSD license
[info]   com.google.protobuf:protobuf-java:2.6.1
[info] 
[info] The Apache Software License, Version 2.0
[info]   log4j:log4j:1.2.17
[info]   de.javakaffee:kryo-serializers:0.37
[info]   com.google.code.gson:gson:2.5
```