### PR TITLE
Fix versions in the installation guide

### DIFF
--- a/docs/manual/data/versions.yml
+++ b/docs/manual/data/versions.yml
@@ -2,6 +2,6 @@ pio: 0.11.0-incubating
 spark: 1.6.3
 spark_download_filename: spark-1.6.3-bin-hadoop2.6
 elasticsearch_download_filename: elasticsearch-1.7.6
-hbase_version: 1.2.5
-hbase_basename: hbase-1.2.5
+hbase_version: 1.2.6
+hbase_basename: hbase-1.2.6
 hbase_variant: bin

--- a/docs/manual/source/install/index.html.md.erb
+++ b/docs/manual/source/install/index.html.md.erb
@@ -24,8 +24,8 @@ limitations under the License.
 It is **very important** to meet the minimum version of the following
 technologies that power Apache PredictionIO (incubating).
 
-* Apache Hadoop 2.4.0 (optional, required only if YARN and HDFS are needed)
-* Apache Spark 1.4.0 for Hadoop 2.4
+* Apache Hadoop 2.6.5 (optional, required only if YARN and HDFS are needed)
+* Apache Spark 1.6.3 for Hadoop 2.6
 * Java SE Development Kit 8
 
 and one of the following sets:
@@ -38,8 +38,8 @@ or
 
 or
 
-* Apache HBase 0.98.6
-* Elasticsearch 1.4.0
+* Apache HBase 0.98.5
+* Elasticsearch 1.7.6
 
 If you are running on a single machine, we recommend a minimum of 2GB memory.
 

--- a/docs/manual/source/install/install-sourcecode.html.md.erb
+++ b/docs/manual/source/install/install-sourcecode.html.md.erb
@@ -68,9 +68,9 @@ versions of dependencies. As of writing, one could build PredictionIO against
 these different dependencies:
 
 * Scala 2.10.x, 2.11.x
-* Spark 1.6.x, 2.x
+* Spark 1.6.x, 2.0.x, 2.1.x
 * Hadoop 2.4.x to 2.7.x
-* Elasticsearch 1.x, 5.x
+* Elasticsearch 1.7.x, 5.x
 
 As an example, if you want to build PredictionIO to support Scala 2.11.8,
 Spark 2.1.0, and Elasticsearch 5.3.0, you can do


### PR DESCRIPTION
This fix is according to the default build settings of PredictionIO 0.11.0-incubating.