### PR TITLE
[PIO-83] Replace semverfi with java-semver

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1393,30 +1393,31 @@ Binary distribution bundles
 --------------------------------------------------------------------------------
 Binary distribution bundles
   
-  me.lessis # semverfi_2.10 # 0.1.3 (https://github.com/softprops/semverfi)
+  com.github.zafarkhaja # java-semver # 0.9.0 (https://github.com/zafarkhaja/jsemver)
   
   which are available under the MIT license (http://opensource.org/licenses/mit-license.php)
   
-Copyright (c) 2012 Doug Tangren
- 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
- 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
- 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The MIT License
+
+Copyright 2012-2014 Zafar Khaja <zafarkhaja@gmail.com>.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 --------------------------------------------------------------------------------
 Binary distribution bundles
   

--- a/tools/build.sbt
+++ b/tools/build.sbt
@@ -21,7 +21,7 @@ import sbtassembly.AssemblyPlugin.autoImport._
 name := "apache-predictionio-tools"
 
 libraryDependencies ++= Seq(
-  "me.lessis"               % "semverfi_2.10"  % "0.1.3",
+  "com.github.zafarkhaja"  %  "java-semver"    % "0.9.0",
   "org.apache.spark"       %% "spark-sql"      % sparkVersion.value % "provided",
   "com.typesafe.akka"      %% "akka-slf4j"     % akkaVersion.value,
   "io.spray"               %% "spray-testkit"  % "1.3.3" % "test",

--- a/tools/src/main/scala/org/apache/predictionio/tools/commands/Management.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/commands/Management.scala
@@ -33,7 +33,7 @@ import org.apache.predictionio.tools.admin.AdminServerConfig
 import akka.actor.ActorSystem
 import java.io.File
 import scala.io.Source
-import semverfi._
+import com.github.zafarkhaja.semver.Version
 
 case class DashboardArgs(
   ip: String = "127.0.0.1",
@@ -127,9 +127,9 @@ object Management extends EitherLogging {
           pioStatus = pioStatus.copy(warnings = pioStatus.warnings :+ warning)
         } else {
           val sparkReleaseVersion = sparkReleaseStrings(1)
-          val parsedMinVersion = Version.apply(sparkMinVersion)
-          val parsedCurrentVersion = Version.apply(sparkReleaseVersion)
-          if (parsedCurrentVersion >= parsedMinVersion) {
+          val parsedMinVersion = Version.valueOf(sparkMinVersion)
+          val parsedCurrentVersion = Version.valueOf(sparkReleaseVersion)
+          if (parsedCurrentVersion.greaterThanOrEqualTo(parsedMinVersion)) {
             info(stripMarginAndNewlines(
               s"""|Apache Spark $sparkReleaseVersion detected (meets minimum
                   |requirement of $sparkMinVersion)"""))

--- a/tools/src/main/scala/org/apache/predictionio/tools/commands/Template.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/commands/Template.scala
@@ -26,7 +26,7 @@ import org.apache.predictionio.tools.EitherLogging
 import org.apache.predictionio.tools.ReturnTypes._
 import org.json4s._
 import org.json4s.native.JsonMethods._
-import semverfi._
+import com.github.zafarkhaja.semver.Version
 
 case class TemplateMetaData(
   pioVersionMin: Option[String] = None)
@@ -59,7 +59,7 @@ object Template extends EitherLogging {
     val metadata = templateMetaData(templateJsonFile)
 
     for (pvm <- metadata.pioVersionMin) {
-      if (Version(BuildInfo.version) < Version(pvm)) {
+      if(Version.valueOf(BuildInfo.version).lessThan(Version.valueOf(pvm))){
         return logAndFail(s"This engine template requires at least PredictionIO $pvm. " +
           s"The template may not work with PredictionIO ${BuildInfo.version}.")
       }


### PR DESCRIPTION
Replace [semverfi](https://github.com/softprops/semverfi) with java-semver because semverfi is no longer maintained. It stopped in Scala 2.10. I looked alternatives of semverfi and found [java-semver](https://github.com/zafarkhaja/jsemver) which has no extra dependency, MIT license and the largest stars on GitHub in alternatives I found.

Other alternatives are:

- https://github.com/jknack/semver.java
- https://github.com/jlindsey/java-semver

This Scala library didn't satisfy our requirements:

- https://github.com/SeerUK/scala-semver