### PR TITLE
[PIO-102] Fix ESEngineInstances `getAll` results out of order (Elasticsearch 5.x)

### DIFF
--- a/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESUtils.scala
+++ b/storage/elasticsearch/src/main/scala/org/apache/predictionio/data/storage/elasticsearch/ESUtils.scala
@@ -150,7 +150,7 @@ object ESUtils {
         val responseJValue = parse(EntityUtils.toString(response.getEntity))
         scroll((responseJValue \ "_scroll_id").extract[String],
           (responseJValue \ "hits" \ "hits").extract[Seq[JValue]],
-          hits.map(h => (h \ "_source").extract[JValue]) ++ results)
+          results ++ hits.map(h => (h \ "_source").extract[JValue]))
       }
     }
 


### PR DESCRIPTION
Fix for [PIO-102](https://issues.apache.org/jira/browse/PIO-102)