### PR TITLE
Fix use of case class in recommendation examples

### DIFF
--- a/examples/scala-parallel-recommendation/blacklist-items/src/main/scala/ALSAlgorithm.scala
+++ b/examples/scala-parallel-recommendation/blacklist-items/src/main/scala/ALSAlgorithm.scala
@@ -103,10 +103,10 @@ class ALSAlgorithm(val ap: ALSAlgorithmParams)
       val itemScores = model
         .recommendProductsWithFilter(userInt, query.num, blackList) // MODIFIED
         .map (r => ItemScore(itemIntStringMap(r.product), r.rating))
-      new PredictedResult(itemScores)
+      PredictedResult(itemScores)
     }.getOrElse{
       logger.info(s"No prediction for unknown user ${query.user}.")
-      new PredictedResult(Array.empty)
+      PredictedResult(Array.empty)
     }
   }
 

--- a/examples/scala-parallel-recommendation/blacklist-items/src/main/scala/Engine.scala
+++ b/examples/scala-parallel-recommendation/blacklist-items/src/main/scala/Engine.scala
@@ -24,20 +24,20 @@ case class Query(
   user: String,
   num: Int,
   blackList: Set[String] // ADDED
-) extends Serializable
+)
 
 case class PredictedResult(
   itemScores: Array[ItemScore]
-) extends Serializable
+)
 
 case class ActualResult(
   ratings: Array[Rating]
-) extends Serializable
+)
 
 case class ItemScore(
   item: String,
   score: Double
-) extends Serializable
+)
 
 object RecommendationEngine extends EngineFactory {
   def apply() = {

--- a/examples/scala-parallel-recommendation/customize-data-prep/src/main/scala/ALSAlgorithm.scala
+++ b/examples/scala-parallel-recommendation/customize-data-prep/src/main/scala/ALSAlgorithm.scala
@@ -101,10 +101,10 @@ class ALSAlgorithm(val ap: ALSAlgorithmParams)
       // index. Convert it to String ID for returning PredictedResult
       val itemScores = model.recommendProducts(userInt, query.num)
         .map (r => ItemScore(itemIntStringMap(r.product), r.rating))
-      new PredictedResult(itemScores)
+      PredictedResult(itemScores)
     }.getOrElse{
       logger.info(s"No prediction for unknown user ${query.user}.")
-      new PredictedResult(Array.empty)
+      PredictedResult(Array.empty)
     }
   }
 

--- a/examples/scala-parallel-recommendation/customize-data-prep/src/main/scala/Engine.scala
+++ b/examples/scala-parallel-recommendation/customize-data-prep/src/main/scala/Engine.scala
@@ -23,20 +23,20 @@ import org.apache.predictionio.controller.Engine
 case class Query(
   user: String,
   num: Int
-) extends Serializable
+)
 
 case class PredictedResult(
   itemScores: Array[ItemScore]
-) extends Serializable
+)
 
 case class ActualResult(
   ratings: Array[Rating]
-) extends Serializable
+)
 
 case class ItemScore(
   item: String,
   score: Double
-) extends Serializable
+)
 
 object RecommendationEngine extends EngineFactory {
   def apply() = {

--- a/examples/scala-parallel-recommendation/customize-serving/src/main/scala/ALSAlgorithm.scala
+++ b/examples/scala-parallel-recommendation/customize-serving/src/main/scala/ALSAlgorithm.scala
@@ -101,10 +101,10 @@ class ALSAlgorithm(val ap: ALSAlgorithmParams)
       // index. Convert it to String ID for returning PredictedResult
       val itemScores = model.recommendProducts(userInt, query.num)
         .map (r => ItemScore(itemIntStringMap(r.product), r.rating))
-      new PredictedResult(itemScores)
+      PredictedResult(itemScores)
     }.getOrElse{
       logger.info(s"No prediction for unknown user ${query.user}.")
-      new PredictedResult(Array.empty)
+      PredictedResult(Array.empty)
     }
   }
 

--- a/examples/scala-parallel-recommendation/customize-serving/src/main/scala/Engine.scala
+++ b/examples/scala-parallel-recommendation/customize-serving/src/main/scala/Engine.scala
@@ -23,20 +23,20 @@ import org.apache.predictionio.controller.Engine
 case class Query(
   user: String,
   num: Int
-) extends Serializable
+)
 
 case class PredictedResult(
   itemScores: Array[ItemScore]
-) extends Serializable
+)
 
 case class ActualResult(
   ratings: Array[Rating]
-) extends Serializable
+)
 
 case class ItemScore(
   item: String,
   score: Double
-) extends Serializable
+)
 
 object RecommendationEngine extends EngineFactory {
   def apply() = {

--- a/examples/scala-parallel-recommendation/reading-custom-events/src/main/scala/ALSAlgorithm.scala
+++ b/examples/scala-parallel-recommendation/reading-custom-events/src/main/scala/ALSAlgorithm.scala
@@ -101,10 +101,10 @@ class ALSAlgorithm(val ap: ALSAlgorithmParams)
       // index. Convert it to String ID for returning PredictedResult
       val itemScores = model.recommendProducts(userInt, query.num)
         .map (r => ItemScore(itemIntStringMap(r.product), r.rating))
-      new PredictedResult(itemScores)
+      PredictedResult(itemScores)
     }.getOrElse{
       logger.info(s"No prediction for unknown user ${query.user}.")
-      new PredictedResult(Array.empty)
+      PredictedResult(Array.empty)
     }
   }
 

--- a/examples/scala-parallel-recommendation/reading-custom-events/src/main/scala/Engine.scala
+++ b/examples/scala-parallel-recommendation/reading-custom-events/src/main/scala/Engine.scala
@@ -23,20 +23,20 @@ import org.apache.predictionio.controller.Engine
 case class Query(
   user: String,
   num: Int
-) extends Serializable
+)
 
 case class PredictedResult(
   itemScores: Array[ItemScore]
-) extends Serializable
+)
 
 case class ActualResult(
   ratings: Array[Rating]
-) extends Serializable
+)
 
 case class ItemScore(
   item: String,
   score: Double
-) extends Serializable
+)
 
 object RecommendationEngine extends EngineFactory {
   def apply() = {

--- a/examples/scala-parallel-recommendation/train-with-view-event/src/main/scala/ALSAlgorithm.scala
+++ b/examples/scala-parallel-recommendation/train-with-view-event/src/main/scala/ALSAlgorithm.scala
@@ -102,10 +102,10 @@ class ALSAlgorithm(val ap: ALSAlgorithmParams)
       // index. Convert it to String ID for returning PredictedResult
       val itemScores = model.recommendProducts(userInt, query.num)
         .map (r => ItemScore(itemIntStringMap(r.product), r.rating))
-      new PredictedResult(itemScores)
+      PredictedResult(itemScores)
     }.getOrElse{
       logger.info(s"No prediction for unknown user ${query.user}.")
-      new PredictedResult(Array.empty)
+      PredictedResult(Array.empty)
     }
   }
 

--- a/examples/scala-parallel-recommendation/train-with-view-event/src/main/scala/Engine.scala
+++ b/examples/scala-parallel-recommendation/train-with-view-event/src/main/scala/Engine.scala
@@ -23,20 +23,20 @@ import org.apache.predictionio.controller.Engine
 case class Query(
   user: String,
   num: Int
-) extends Serializable
+)
 
 case class PredictedResult(
   itemScores: Array[ItemScore]
-) extends Serializable
+)
 
 case class ActualResult(
   ratings: Array[Rating]
-) extends Serializable
+)
 
 case class ItemScore(
   item: String,
   score: Double
-) extends Serializable
+)
 
 object RecommendationEngine extends EngineFactory {
   def apply() = {


### PR DESCRIPTION
According to this template fix: https://github.com/apache/incubator-predictionio-template-recommender/pull/18