### PR TITLE
Fix use of case class in recommendation examples (docs)

### DIFF
--- a/docs/manual/source/templates/recommendation/blacklist-items.html.md
+++ b/docs/manual/source/templates/recommendation/blacklist-items.html.md
@@ -37,7 +37,7 @@ case class Query(
   user: String,
   num: Int,
   blackList: Set[String] // ADDED
-) extends Serializable
+)
 ```
 
 ## Filter the Data
@@ -93,10 +93,10 @@ Lets modify method `predict` in MyRecommendation/src/main/scala/***ALSAlgorithm.
       val itemScores = model
         .recommendProductsWithFilter(userInt, query.num, blackList) // MODIFIED
         .map (r => ItemScore(itemIntStringMap(r.product), r.rating))
-      new PredictedResult(itemScores)
+      PredictedResult(itemScores)
     }.getOrElse{
       logger.info(s"No prediction for unknown user ${query.user}.")
-      new PredictedResult(Array.empty)
+      PredictedResult(Array.empty)
     }
   }
 ```

--- a/docs/manual/source/templates/recommendation/dase.html.md.erb
+++ b/docs/manual/source/templates/recommendation/dase.html.md.erb
@@ -36,7 +36,7 @@ defines the format of such **query**:
 case class Query(
   user: String,
   num: Int
-) extends Serializable
+)
 ```
 
 The `PredictedResult` case class defines the format of **predicted result**,
@@ -56,12 +56,12 @@ with:
 ```scala
 case class PredictedResult(
   itemScores: Array[ItemScore]
-) extends Serializable
+)
 
 case class ItemScore(
   item: String,
   score: Double
-) extends Serializable
+)
 ```
 
 Finally, `RecommendationEngine` is the *Engine Factory* that defines the
@@ -386,10 +386,10 @@ predicts the top *num* of items a user will like.
       // index. Convert it to String ID for returning PredictedResult
       val itemScores = model.recommendProducts(userInt, query.num)
         .map (r => ItemScore(itemIntStringMap(r.product), r.rating))
-      new PredictedResult(itemScores)
+      PredictedResult(itemScores)
     }.getOrElse{
       logger.info(s"No prediction for unknown user ${query.user}.")
-      new PredictedResult(Array.empty)
+      PredictedResult(Array.empty)
     }
   }
 ```

--- a/docs/manual/source/templates/recommendation/evaluation.html.md.erb
+++ b/docs/manual/source/templates/recommendation/evaluation.html.md.erb
@@ -180,7 +180,7 @@ It stores the list of ratings in the validation set for a user.
 ```scala
 case class ActualResult(
   ratings: Array[Rating]
-) extends Serializable
+)
 ```
 
 ### Implement Data Generate Method in DataSource


### PR DESCRIPTION
According to this template fix: https://github.com/apache/incubator-predictionio-template-recommender/pull/18