### PR TITLE
Fix use of case class in classification examples

### DIFF
--- a/examples/scala-parallel-classification/add-algorithm/src/main/scala/DataSource.scala
+++ b/examples/scala-parallel-classification/add-algorithm/src/main/scala/DataSource.scala
@@ -119,7 +119,7 @@ class DataSource(val dsp: DataSourceParams)
         new TrainingData(trainingPoints),
         new EmptyEvaluationInfo(),
         testingPoints.map {
-          p => (new Query(p.features(0), p.features(1), p.features(2)), new ActualResult(p.label))
+          p => (Query(p.features(0), p.features(1), p.features(2)), ActualResult(p.label))
         }
       )
     }

--- a/examples/scala-parallel-classification/add-algorithm/src/main/scala/Engine.scala
+++ b/examples/scala-parallel-classification/add-algorithm/src/main/scala/Engine.scala
@@ -20,19 +20,19 @@ package org.apache.predictionio.examples.classification
 import org.apache.predictionio.controller.EngineFactory
 import org.apache.predictionio.controller.Engine
 
-class Query(
-  val attr0 : Double,
-  val attr1 : Double,
-  val attr2 : Double
-) extends Serializable
+case class Query(
+  attr0 : Double,
+  attr1 : Double,
+  attr2 : Double
+)
 
-class PredictedResult(
-  val label: Double
-) extends Serializable
+case class PredictedResult(
+  label: Double
+)
 
-class ActualResult(
-  val label: Double
-) extends Serializable
+case class ActualResult(
+  label: Double
+)
 
 object ClassificationEngine extends EngineFactory {
   def apply() = {

--- a/examples/scala-parallel-classification/add-algorithm/src/main/scala/Evaluation.scala
+++ b/examples/scala-parallel-classification/add-algorithm/src/main/scala/Evaluation.scala
@@ -31,7 +31,7 @@ case class Accuracy()
 
 object AccuracyEvaluation extends Evaluation {
   // Define Engine and Metric used in Evaluation
-  engineMetric = (ClassificationEngine(), new Accuracy())
+  engineMetric = (ClassificationEngine(), Accuracy())
 }
 
 object EngineParamsList extends EngineParamsGenerator {

--- a/examples/scala-parallel-classification/add-algorithm/src/main/scala/NaiveBayesAlgorithm.scala
+++ b/examples/scala-parallel-classification/add-algorithm/src/main/scala/NaiveBayesAlgorithm.scala
@@ -51,7 +51,7 @@ class NaiveBayesAlgorithm(val ap: AlgorithmParams)
     val label = model.predict(Vectors.dense(
       Array(query.attr0, query.attr1, query.attr2)
     ))
-    new PredictedResult(label)
+    PredictedResult(label)
   }
 
 }

--- a/examples/scala-parallel-classification/add-algorithm/src/main/scala/PrecisionEvaluation.scala
+++ b/examples/scala-parallel-classification/add-algorithm/src/main/scala/PrecisionEvaluation.scala
@@ -40,5 +40,5 @@ case class Precision(label: Double)
 }
 
 object PrecisionEvaluation extends Evaluation {
-  engineMetric = (ClassificationEngine(), new Precision(label = 1.0))
+  engineMetric = (ClassificationEngine(), Precision(label = 1.0))
 }

--- a/examples/scala-parallel-classification/add-algorithm/src/main/scala/RandomForestAlgorithm.scala
+++ b/examples/scala-parallel-classification/add-algorithm/src/main/scala/RandomForestAlgorithm.scala
@@ -64,7 +64,7 @@ class RandomForestAlgorithm(val ap: RandomForestAlgorithmParams) // CHANGED
     val label = model.predict(Vectors.dense(
       Array(query.attr0, query.attr1, query.attr2)
     ))
-    new PredictedResult(label)
+    PredictedResult(label)
   }
 
 }

--- a/examples/scala-parallel-classification/reading-custom-properties/src/main/scala/DataSource.scala
+++ b/examples/scala-parallel-classification/reading-custom-properties/src/main/scala/DataSource.scala
@@ -126,7 +126,7 @@ class DataSource(val dsp: DataSourceParams)
         new EmptyEvaluationInfo(),
         testingPoints.map {
           // MODIFIED
-          p => (new Query(p.features(0), p.features(1), p.features(2), p.features(3)), new ActualResult(p.label))
+          p => (Query(p.features(0), p.features(1), p.features(2), p.features(3)), ActualResult(p.label))
         }
       )
     }

--- a/examples/scala-parallel-classification/reading-custom-properties/src/main/scala/Engine.scala
+++ b/examples/scala-parallel-classification/reading-custom-properties/src/main/scala/Engine.scala
@@ -21,20 +21,20 @@ import org.apache.predictionio.controller.EngineFactory
 import org.apache.predictionio.controller.Engine
 
 // MODIFIED
-class Query(
-  val featureA : Double,
-  val featureB : Double,
-  val featureC : Double,
-  val featureD : Double
-) extends Serializable
+case class Query(
+  featureA : Double,
+  featureB : Double,
+  featureC : Double,
+  featureD : Double
+)
 
-class PredictedResult(
-  val label: Double
-) extends Serializable
+case class PredictedResult(
+  label: Double
+)
 
-class ActualResult(
-  val label: Double
-) extends Serializable
+case class ActualResult(
+  label: Double
+)
 
 object ClassificationEngine extends EngineFactory {
   def apply() = {

--- a/examples/scala-parallel-classification/reading-custom-properties/src/main/scala/Evaluation.scala
+++ b/examples/scala-parallel-classification/reading-custom-properties/src/main/scala/Evaluation.scala
@@ -31,7 +31,7 @@ case class Accuracy()
 
 object AccuracyEvaluation extends Evaluation {
   // Define Engine and Metric used in Evaluation
-  engineMetric = (ClassificationEngine(), new Accuracy())
+  engineMetric = (ClassificationEngine(), Accuracy())
 }
 
 object EngineParamsList extends EngineParamsGenerator {

--- a/examples/scala-parallel-classification/reading-custom-properties/src/main/scala/NaiveBayesAlgorithm.scala
+++ b/examples/scala-parallel-classification/reading-custom-properties/src/main/scala/NaiveBayesAlgorithm.scala
@@ -52,7 +52,7 @@ class NaiveBayesAlgorithm(val ap: AlgorithmParams)
       // MODIFIED
       Array(query.featureA, query.featureB, query.featureC, query.featureD)
     ))
-    new PredictedResult(label)
+    PredictedResult(label)
   }
 
 }

--- a/examples/scala-parallel-classification/reading-custom-properties/src/main/scala/PrecisionEvaluation.scala
+++ b/examples/scala-parallel-classification/reading-custom-properties/src/main/scala/PrecisionEvaluation.scala
@@ -40,5 +40,5 @@ case class Precision(label: Double)
 }
 
 object PrecisionEvaluation extends Evaluation {
-  engineMetric = (ClassificationEngine(), new Precision(label = 1.0))
+  engineMetric = (ClassificationEngine(), Precision(label = 1.0))
 }


### PR DESCRIPTION
According to this template fix: https://github.com/apache/incubator-predictionio-template-attribute-based-classifier/pull/11