### PR TITLE
[PIO-105] Batch Predictions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -162,7 +162,8 @@ val tools = (project in file("tools")).
   settings(commonSettings: _*).
   settings(commonTestSettings: _*).
   enablePlugins(GenJavadocPlugin).
-  enablePlugins(SbtTwirl)
+  enablePlugins(SbtTwirl).
+  settings(publishArtifact := false)
 
 val e2 = (project in file("e2")).
   settings(commonSettings: _*).

--- a/build.sbt
+++ b/build.sbt
@@ -162,8 +162,7 @@ val tools = (project in file("tools")).
   settings(commonSettings: _*).
   settings(commonTestSettings: _*).
   enablePlugins(GenJavadocPlugin).
-  enablePlugins(SbtTwirl).
-  settings(publishArtifact := false)
+  enablePlugins(SbtTwirl)
 
 val e2 = (project in file("e2")).
   settings(commonSettings: _*).

--- a/core/src/main/scala/org/apache/predictionio/workflow/BatchPredict.scala
+++ b/core/src/main/scala/org/apache/predictionio/workflow/BatchPredict.scala
@@ -185,7 +185,9 @@ object BatchPredict extends Logging {
       mode = "Batch Predict (runner)",
       sparkEnv = engineInstance.sparkConf)
 
-    val inputRDD: RDD[String] = runSparkContext.textFile(config.inputFilePath)
+    val inputRDD: RDD[String] = runSparkContext.
+      textFile(config.inputFilePath).
+      filter(_.trim.nonEmpty)
     val queriesRDD: RDD[String] = config.queryPartitions match {
       case Some(p) => inputRDD.repartition(p)
       case None => inputRDD

--- a/core/src/main/scala/org/apache/predictionio/workflow/BatchPredict.scala
+++ b/core/src/main/scala/org/apache/predictionio/workflow/BatchPredict.scala
@@ -70,11 +70,11 @@ object BatchPredict extends Logging {
     val parser = new scopt.OptionParser[BatchPredictConfig]("BatchPredict") {
       opt[String]("input") action { (x, c) =>
         c.copy(inputFilePath = x)
-      } text("Path to file containing input queries; a " + 
+      } text("Path to file containing input queries; a " +
         "multi-object JSON file with one object per line.")
       opt[String]("output") action { (x, c) =>
         c.copy(outputFilePath = x)
-      } text("Path to file containing output predictions; a " + 
+      } text("Path to file containing output predictions; a " +
         "multi-object JSON file with one object per line.")
       opt[String]("engineId") action { (x, c) =>
         c.copy(engineId = Some(x))

--- a/core/src/main/scala/org/apache/predictionio/workflow/BatchPredict.scala
+++ b/core/src/main/scala/org/apache/predictionio/workflow/BatchPredict.scala
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.predictionio.workflow
+
+import java.io.Serializable
+
+import com.twitter.bijection.Injection
+import com.twitter.chill.{KryoBase, KryoInjection, ScalaKryoInstantiator}
+import de.javakaffee.kryoserializers.SynchronizedCollectionsSerializer
+import grizzled.slf4j.Logging
+import org.apache.predictionio.controller.{Engine, Utils}
+import org.apache.predictionio.core.{BaseAlgorithm, BaseServing, Doer}
+import org.apache.predictionio.data.storage.{EngineInstance, Storage}
+import org.apache.predictionio.workflow.JsonExtractorOption.JsonExtractorOption
+import org.apache.spark.rdd.RDD
+import org.json4s._
+import org.json4s.native.JsonMethods._
+import scala.language.existentials
+
+case class BatchPredictConfig(
+  inputFilePath: String = "batchpredict-input.json",
+  outputFilePath: String = "batchpredict-output.json",
+  engineInstanceId: String = "",
+  engineId: Option[String] = None,
+  engineVersion: Option[String] = None,
+  engineVariant: String = "",
+  env: Option[String] = None,
+  verbose: Boolean = false,
+  debug: Boolean = false,
+  jsonExtractor: JsonExtractorOption = JsonExtractorOption.Both)
+
+object BatchPredict extends Logging {
+
+  class KryoInstantiator(classLoader: ClassLoader) extends ScalaKryoInstantiator {
+    override def newKryo(): KryoBase = {
+      val kryo = super.newKryo()
+      kryo.setClassLoader(classLoader)
+      SynchronizedCollectionsSerializer.registerSerializers(kryo)
+      kryo
+    }
+  }
+
+  object KryoInstantiator extends Serializable {
+    def newKryoInjection : Injection[Any, Array[Byte]] = {
+      val kryoInstantiator = new KryoInstantiator(getClass.getClassLoader)
+      KryoInjection.instance(kryoInstantiator)
+    }
+  }
+
+  val engineInstances = Storage.getMetaDataEngineInstances
+  val modeldata = Storage.getModelDataModels
+
+  def main(args: Array[String]): Unit = {
+    val parser = new scopt.OptionParser[BatchPredictConfig]("BatchPredict") {
+      opt[String]("input") action { (x, c) =>
+        c.copy(inputFilePath = x)
+      } text("Path to file containing input queries; a " + 
+        "multi-object JSON file with one object per line.")
+      opt[String]("output") action { (x, c) =>
+        c.copy(outputFilePath = x)
+      } text("Path to file containing output predictions; a " + 
+        "multi-object JSON file with one object per line.")
+      opt[String]("engineId") action { (x, c) =>
+        c.copy(engineId = Some(x))
+      } text("Engine ID.")
+      opt[String]("engineId") action { (x, c) =>
+        c.copy(engineId = Some(x))
+      } text("Engine ID.")
+      opt[String]("engineVersion") action { (x, c) =>
+        c.copy(engineVersion = Some(x))
+      } text("Engine version.")
+      opt[String]("engine-variant") required() action { (x, c) =>
+        c.copy(engineVariant = x)
+      } text("Engine variant JSON.")
+      opt[String]("env") action { (x, c) =>
+        c.copy(env = Some(x))
+      } text("Comma-separated list of environmental variables (in 'FOO=BAR' " +
+        "format) to pass to the Spark execution environment.")
+      opt[String]("engineInstanceId") required() action { (x, c) =>
+        c.copy(engineInstanceId = x)
+      } text("Engine instance ID.")
+      opt[Unit]("verbose") action { (x, c) =>
+        c.copy(verbose = true)
+      } text("Enable verbose output.")
+      opt[Unit]("debug") action { (x, c) =>
+        c.copy(debug = true)
+      } text("Enable debug output.")
+      opt[String]("json-extractor") action { (x, c) =>
+        c.copy(jsonExtractor = JsonExtractorOption.withName(x))
+      }
+    }
+
+    parser.parse(args, BatchPredictConfig()) map { config =>
+      WorkflowUtils.modifyLogging(config.verbose)
+      engineInstances.get(config.engineInstanceId) map { engineInstance =>
+
+        val engine = getEngine(engineInstance)
+
+        run(config, engineInstance, engine)
+
+      } getOrElse {
+        error(s"Invalid engine instance ID. Aborting batch predict.")
+      }
+    }
+  }
+
+  def getEngine(engineInstance: EngineInstance): Engine[_, _, _, _, _, _] = {
+
+    val engineFactoryName = engineInstance.engineFactory
+
+    val (engineLanguage, engineFactory) =
+      WorkflowUtils.getEngine(engineFactoryName, getClass.getClassLoader)
+    val maybeEngine = engineFactory()
+
+    // EngineFactory return a base engine, which may not be deployable.
+    if (!maybeEngine.isInstanceOf[Engine[_,_,_,_,_,_]]) {
+      throw new NoSuchMethodException(
+        s"Engine $maybeEngine cannot be used for batch predict")
+    }
+
+    maybeEngine.asInstanceOf[Engine[_,_,_,_,_,_]]
+  }
+
+  def run[Q, P](
+    config: BatchPredictConfig,
+    engineInstance: EngineInstance,
+    engine: Engine[_, _, _, Q, P, _]): Unit = {
+
+    val engineParams = engine.engineInstanceToEngineParams(
+      engineInstance, config.jsonExtractor)
+
+    val kryo = KryoInstantiator.newKryoInjection
+
+    val modelsFromEngineInstance =
+      kryo.invert(modeldata.get(engineInstance.id).get.models).get.
+      asInstanceOf[Seq[Any]]
+
+    val prepareSparkContext = WorkflowContext(
+      batch = engineInstance.engineFactory,
+      executorEnv = engineInstance.env,
+      mode = "Batch Predict (model)",
+      sparkEnv = engineInstance.sparkConf)
+
+    val models = engine.prepareDeploy(
+      prepareSparkContext,
+      engineParams,
+      engineInstance.id,
+      modelsFromEngineInstance,
+      params = WorkflowParams()
+    )
+
+    val algorithms = engineParams.algorithmParamsList.map { case (n, p) =>
+      Doer(engine.algorithmClassMap(n), p)
+    }
+
+    val servingParamsWithName = engineParams.servingParams
+
+    val serving = Doer(engine.servingClassMap(servingParamsWithName._1),
+      servingParamsWithName._2)
+
+    val runSparkContext = WorkflowContext(
+      batch = engineInstance.engineFactory,
+      executorEnv = engineInstance.env,
+      mode = "Batch Predict (runner)",
+      sparkEnv = engineInstance.sparkConf)
+
+    val queriesRDD: RDD[String] = runSparkContext.textFile(config.inputFilePath)
+
+    val predictionsRDD: RDD[String] = queriesRDD.map { queryString =>
+      val jsonExtractorOption = config.jsonExtractor
+      // Extract Query from Json
+      val query = JsonExtractor.extract(
+        jsonExtractorOption,
+        queryString,
+        algorithms.head.queryClass,
+        algorithms.head.querySerializer,
+        algorithms.head.gsonTypeAdapterFactories
+      )
+      // Deploy logic. First call Serving.supplement, then Algo.predict,
+      // finally Serving.serve.
+      val supplementedQuery = serving.supplementBase(query)
+      // TODO: Parallelize the following.
+      val predictions = algorithms.zipWithIndex.map { case (a, ai) =>
+        a.predictBase(models(ai), supplementedQuery)
+      }
+      // Notice that it is by design to call Serving.serve with the
+      // *original* query.
+      val prediction = serving.serveBase(query, predictions)
+      // Combine query with prediction, so the batch results are
+      // self-descriptive.
+      val predictionJValue = JsonExtractor.toJValue(
+        jsonExtractorOption,
+        Map("query" -> query,
+            "prediction" -> prediction),
+        algorithms.head.querySerializer,
+        algorithms.head.gsonTypeAdapterFactories)
+      // Return JSON string
+      compact(render(predictionJValue))
+    }
+
+    predictionsRDD.saveAsTextFile(config.outputFilePath)
+  }
+}

--- a/tools/src/main/scala/org/apache/predictionio/tools/RunBatchPredict.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/RunBatchPredict.scala
@@ -31,6 +31,7 @@ import scala.sys.process._
 case class BatchPredictArgs(
   inputFilePath: String = "batchpredict-input.json",
   outputFilePath: String = "batchpredict-output.json",
+  queryPartitions: Option[Int] = None,
   variantJson: Option[File] = None,
   jsonExtractor: JsonExtractorOption = JsonExtractorOption.Both)
 
@@ -58,6 +59,9 @@ object RunBatchPredict extends Logging {
       "--engine-variant",
       batchPredictArgs.variantJson.getOrElse(
         new File(engineDirPath, "engine.json")).getCanonicalPath) ++
+      (if (batchPredictArgs.queryPartitions.isEmpty) Seq()
+        else Seq("--query-partitions",
+                  batchPredictArgs.queryPartitions.get.toString)) ++
       (if (verbose) Seq("--verbose") else Seq()) ++
       Seq("--json-extractor", batchPredictArgs.jsonExtractor.toString)
 

--- a/tools/src/main/scala/org/apache/predictionio/tools/RunBatchPredict.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/RunBatchPredict.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.predictionio.tools
+
+import org.apache.predictionio.tools.Common._
+import org.apache.predictionio.tools.ReturnTypes._
+import org.apache.predictionio.workflow.JsonExtractorOption
+import org.apache.predictionio.workflow.JsonExtractorOption.JsonExtractorOption
+
+import java.io.File
+import grizzled.slf4j.Logging
+
+import scala.sys.process._
+
+case class BatchPredictArgs(
+  inputFilePath: String = "batchpredict-input.json",
+  outputFilePath: String = "batchpredict-output.json",
+  variantJson: Option[File] = None,
+  jsonExtractor: JsonExtractorOption = JsonExtractorOption.Both)
+
+
+object RunBatchPredict extends Logging {
+
+  def runBatchPredict(
+    engineInstanceId: String,
+    batchPredictArgs: BatchPredictArgs,
+    sparkArgs: SparkArgs,
+    pioHome: String,
+    engineDirPath: String,
+    verbose: Boolean = false): Expected[(Process, () => Unit)] = {
+
+    val jarFiles = jarFilesForScala(engineDirPath).map(_.toURI) ++
+      Option(new File(pioHome, "plugins").listFiles())
+        .getOrElse(Array.empty[File]).map(_.toURI)
+    val args = Seq[String](
+      "--input",
+      batchPredictArgs.inputFilePath,
+      "--output",
+      batchPredictArgs.outputFilePath,
+      "--engineInstanceId",
+      engineInstanceId,
+      "--engine-variant",
+      batchPredictArgs.variantJson.getOrElse(
+        new File(engineDirPath, "engine.json")).getCanonicalPath) ++
+      (if (verbose) Seq("--verbose") else Seq()) ++
+      Seq("--json-extractor", batchPredictArgs.jsonExtractor.toString)
+
+    Runner.runOnSpark(
+      "org.apache.predictionio.workflow.BatchPredict",
+      args, sparkArgs, jarFiles, pioHome, verbose)
+  }
+}

--- a/tools/src/main/scala/org/apache/predictionio/tools/commands/Engine.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/commands/Engine.scala
@@ -263,7 +263,7 @@ object Engine extends EitherLogging {
     }
   }
 
-  /** Batch predict with an engine. 
+  /** Batch predict with an engine.
     *
     * @param ea An instance of [[EngineArgs]]
     * @param engineInstanceId An instance of [[engineInstanceId]]

--- a/tools/src/main/scala/org/apache/predictionio/tools/commands/Engine.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/commands/Engine.scala
@@ -21,8 +21,9 @@ import org.apache.predictionio.core.BuildInfo
 import org.apache.predictionio.controller.Utils
 import org.apache.predictionio.data.storage
 import org.apache.predictionio.tools.EitherLogging
-import org.apache.predictionio.tools.{RunWorkflow, RunServer}
-import org.apache.predictionio.tools.{DeployArgs, WorkflowArgs, SparkArgs, ServerArgs}
+import org.apache.predictionio.tools.{RunWorkflow, RunServer, RunBatchPredict}
+import org.apache.predictionio.tools.{
+  DeployArgs, WorkflowArgs, SparkArgs, ServerArgs, BatchPredictArgs}
 import org.apache.predictionio.tools.console.Console
 import org.apache.predictionio.tools.Common._
 import org.apache.predictionio.tools.ReturnTypes._
@@ -259,6 +260,56 @@ object Engine extends EitherLogging {
       case _: Throwable =>
         logAndFail("Another process might be occupying " +
           s"${da.ip}:${da.port}. Unable to undeploy.")
+    }
+  }
+
+  /** Batch predict with an engine. 
+    *
+    * @param ea An instance of [[EngineArgs]]
+    * @param engineInstanceId An instance of [[engineInstanceId]]
+    * @param batchPredictArgs An instance of [[BatchPredictArgs]]
+    * @param sparkArgs An instance of [[SparkArgs]]
+    * @param pioHome [[String]] with a path to PIO installation
+    * @param verbose A [[Boolean]]
+    * @return An instance of [[Expected]] contaning either [[Left]]
+    *         with an error message or [[Right]] with a handle to process
+    *         of a running angine  and a function () => Unit,
+    *         that must be called when the process is complete
+    */
+  def batchPredict(
+    ea: EngineArgs,
+    engineInstanceId: Option[String],
+    batchPredictArgs: BatchPredictArgs,
+    sparkArgs: SparkArgs,
+    pioHome: String,
+    verbose: Boolean = false): Expected[(Process, () => Unit)] = {
+
+    val engineDirPath = getEngineDirPath(ea.engineDir)
+    val verifyResult = Template.verifyTemplateMinVersion(
+      new File(engineDirPath, "template.json"))
+    if (verifyResult.isLeft) {
+      return Left(verifyResult.left.get)
+    }
+    val ei = Console.getEngineInfo(
+      batchPredictArgs.variantJson.getOrElse(new File(engineDirPath, "engine.json")),
+      engineDirPath)
+    val engineInstances = storage.Storage.getMetaDataEngineInstances
+    val engineInstance = engineInstanceId map { eid =>
+      engineInstances.get(eid)
+    } getOrElse {
+      engineInstances.getLatestCompleted(
+        ei.engineId, ei.engineVersion, ei.variantId)
+    }
+    engineInstance map { r =>
+      RunBatchPredict.runBatchPredict(
+        r.id, batchPredictArgs, sparkArgs, pioHome, engineDirPath, verbose)
+    } getOrElse {
+      engineInstanceId map { eid =>
+        logAndFail(s"Invalid engine instance ID ${eid}. Aborting.")
+      } getOrElse {
+        logAndFail(s"No valid engine instance found for engine ${ei.engineId} " +
+          s"${ei.engineVersion}.\nTry running 'train' before 'batchpredict'. Aborting.")
+      }
     }
   }
 

--- a/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
@@ -345,6 +345,11 @@ object Console extends Logging {
                   "Accepts any valid Hadoop file URL. Actual output will be\n" +
                   "written as Hadoop partition files in a directory with the\n" +
                   "output name. Default: batchpredict-output.json"),
+          opt[Int]("query-partitions") action { (x, c) =>
+            c.copy(batchPredict = c.batchPredict.copy(queryPartitions = Some(x)))
+          } text("Limit concurrency of predictions by setting the number\n" +
+                  "of partitions used internally for the RDD of queries.\n" +
+                  "Default: number created by Spark context's `textFile`"),
           opt[String]("engine-instance-id") action { (x, c) =>
             c.copy(engineInstanceId = Some(x))
           } text("Engine instance ID."),
@@ -688,6 +693,7 @@ object Console extends Logging {
             BatchPredictArgs(
               ca.batchPredict.inputFilePath,
               ca.batchPredict.outputFilePath,
+              ca.batchPredict.queryPartitions,
               ca.workflow.variantJson,
               ca.workflow.jsonExtractor),
             ca.spark,

--- a/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
@@ -340,9 +340,9 @@ object Console extends Logging {
                   "file URL. Default: batchpredict-input.json"),
           opt[String]("output") action { (x, c) =>
             c.copy(batchPredict = c.batchPredict.copy(outputFilePath = x))
-          } text("Path to file to receive results; a multi-object JSON file\n" + 
-                  "with one object per line, the prediction + original query.\n" + 
-                  "Accepts any valid Hadoop file URL. Actual output will be\n" + 
+          } text("Path to file to receive results; a multi-object JSON file\n" +
+                  "with one object per line, the prediction + original query.\n" +
+                  "Accepts any valid Hadoop file URL. Actual output will be\n" +
                   "written as Hadoop partition files in a directory with the\n" +
                   "output name. Default: batchpredict-output.json"),
           opt[String]("engine-instance-id") action { (x, c) =>

--- a/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
@@ -327,21 +327,24 @@ object Console extends Logging {
       note("")
       cmd("batchpredict").
         text("Use an engine instance to process batch predictions. This\n" +
-          "command will send all pass-through arguments to its underlying\n" +
-          "spark-submit command.").
+              "command will pass all pass-through arguments to its underlying\n" +
+              "spark-submit command. All algorithm classes used in the engine\n" +
+              "must be serializable.").
         action { (_, c) =>
           c.copy(commands = c.commands :+ "batchpredict")
         } children(
           opt[String]("input") action { (x, c) =>
             c.copy(batchPredict = c.batchPredict.copy(inputFilePath = x))
-          } text("Path to file containing input queries; a " + 
-            "multi-object JSON file with one object per line; " + 
-            "default is 'batchpredict-input.json'."),
+          } text("Path to file containing queries; a multi-object JSON file\n" +
+                  "with one query object per line. Accepts any valid Hadoop\n" +
+                  "file URL. Default: batchpredict-input.json"),
           opt[String]("output") action { (x, c) =>
             c.copy(batchPredict = c.batchPredict.copy(outputFilePath = x))
-          } text("Path to file containing output predictions; a " + 
-            "multi-object JSON file with one object per line; " + 
-            "default is 'batchpredict-output.json'."),
+          } text("Path to file to receive results; a multi-object JSON file\n" + 
+                  "with one object per line, the prediction + original query.\n" + 
+                  "Accepts any valid Hadoop file URL. Actual output will be\n" + 
+                  "written as Hadoop partition files in a directory with the\n" +
+                  "output name. Default: batchpredict-output.json"),
           opt[String]("engine-instance-id") action { (x, c) =>
             c.copy(engineInstanceId = Some(x))
           } text("Engine instance ID."),

--- a/tools/src/main/scala/org/apache/predictionio/tools/console/Pio.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/console/Pio.scala
@@ -18,7 +18,8 @@
 package org.apache.predictionio.tools.console
 
 import org.apache.predictionio.tools.{
-  EventServerArgs, SparkArgs, WorkflowArgs, ServerArgs, DeployArgs}
+  EventServerArgs, SparkArgs, WorkflowArgs, ServerArgs,
+  DeployArgs, BatchPredictArgs}
 import org.apache.predictionio.tools.commands.{
   DashboardArgs, AdminServerArgs, ImportArgs, ExportArgs,
   BuildArgs, EngineArgs, Management, Engine, Import, Export,
@@ -103,6 +104,16 @@ object Pio extends Logging {
         ea, engineInstanceId, serverArgs, sparkArgs, pioHome, verbose))
 
   def undeploy(da: DeployArgs): Int = Engine.undeploy(da)
+
+  def batchPredict(
+    ea: EngineArgs,
+    engineInstanceId: Option[String],
+    batchPredictArgs: BatchPredictArgs,
+    sparkArgs: SparkArgs,
+    pioHome: String,
+    verbose: Boolean = false): Int =
+      processAwaitAndClean(Engine.batchPredict(
+        ea, engineInstanceId, batchPredictArgs, sparkArgs, pioHome, verbose))
 
   def dashboard(da: DashboardArgs): Int = {
     Management.dashboard(da).awaitTermination

--- a/tools/src/main/twirl/org/apache/predictionio/tools/console/batchpredict.scala.txt
+++ b/tools/src/main/twirl/org/apache/predictionio/tools/console/batchpredict.scala.txt
@@ -1,0 +1,15 @@
+Usage: pio batchpredict [--input <value>]
+                        [--output <value>]
+                        [--engine-instance-id <value>]
+
+Use an engine instance to process batch predictions. This command will pass all
+pass-through arguments to its underlying spark-submit command.
+
+  --input <value>
+      Path to file containing input queries; a multi-object JSON file with one
+      object per line. Default: batchpredict-input.json
+  --output <value>
+      Path to file containing output queries; a multi-object JSON file with one
+      object per line. Default: batchpredict-output.json
+  --engine-instance-id <value>
+      Engine instance ID. Default: the latest trained instance.

--- a/tools/src/main/twirl/org/apache/predictionio/tools/console/batchpredict.scala.txt
+++ b/tools/src/main/twirl/org/apache/predictionio/tools/console/batchpredict.scala.txt
@@ -1,5 +1,6 @@
 Usage: pio batchpredict [--input <value>]
                         [--output <value>]
+                        [--query-partitions <value>]
                         [--engine-instance-id <value>]
 
 Use an engine instance to process batch predictions. This command will pass all
@@ -16,5 +17,9 @@ classes used in the engine must be serializable.
       valid Hadoop file URL. Actual output will be written as Hadoop
       partition files in a directory with the output name.
       Default: batchpredict-output.json
+  --query-partitions <value>
+      Limit concurrency of predictions by setting the number of partitions
+      used internally for the RDD of queries.
+      Default: number created by Spark context's `textFile`
   --engine-instance-id <value>
       Engine instance ID. Default: the latest trained instance.

--- a/tools/src/main/twirl/org/apache/predictionio/tools/console/batchpredict.scala.txt
+++ b/tools/src/main/twirl/org/apache/predictionio/tools/console/batchpredict.scala.txt
@@ -3,13 +3,18 @@ Usage: pio batchpredict [--input <value>]
                         [--engine-instance-id <value>]
 
 Use an engine instance to process batch predictions. This command will pass all
-pass-through arguments to its underlying spark-submit command.
+pass-through arguments to its underlying spark-submit command. All algorithm
+classes used in the engine must be serializable.
 
   --input <value>
-      Path to file containing input queries; a multi-object JSON file with one
-      object per line. Default: batchpredict-input.json
+      Path to file containing queries; a multi-object JSON file with one
+      query object per line. Accepts any valid Hadoop file URL.
+      Default: batchpredict-input.json
   --output <value>
-      Path to file containing output queries; a multi-object JSON file with one
-      object per line. Default: batchpredict-output.json
+      Path to file to receive results; a multi-object JSON file with one
+      object per line, the prediction + original query. Accepts any
+      valid Hadoop file URL. Actual output will be written as Hadoop
+      partition files in a directory with the output name.
+      Default: batchpredict-output.json
   --engine-instance-id <value>
       Engine instance ID. Default: the latest trained instance.

--- a/tools/src/main/twirl/org/apache/predictionio/tools/console/main.scala.txt
+++ b/tools/src/main/twirl/org/apache/predictionio/tools/console/main.scala.txt
@@ -38,6 +38,7 @@ The most commonly used pio commands are:
     build         Build an engine at the current directory
     train         Kick off a training using an engine
     deploy        Deploy an engine as an engine server
+    batchpredict  Process bulk predictions with an engine
     eventserver   Launch an Event Server
     app           Manage apps that are used by the Event Server
     accesskey     Manage app access keys


### PR DESCRIPTION
JIRA issue [PIO-105](https://issues.apache.org/jira/browse/PIO-105)

Provides a new `pio batchpredict` command using the same core logic & APIs as `pio deploy`. The only intentional difference between `batchpredict` and `deploy` is that the new `batchpredict` processes all queries via RDD#map.

As a result, a new engine constraint is added only for `batchpredict`:  
**All algorithm classes must be serializable.**

Reads from multi-object JSON input file. Example:

```json
{"user":"1"}
{"user":"2"}
{"user":"3"}
{"user":"4"}
{"user":"5"}
```

Writes to multi-object JSON output file (actually Hadoop partition files). Example:

```json
{"query":{"user":"1"},"prediction":{"itemScores":[{"item":"1","score":33},{"item":"2","score":32}]}}
{"query":{"user":"2"},"prediction":{"itemScores":[{"item":"5","score":55},{"item":"3","score":28}]}}
{"query":{"user":"3"},"prediction":{"itemScores":[{"item":"2","score":16},{"item":"3","score":12}]}}
{"query":{"user":"4"},"prediction":{"itemScores":[{"item":"3","score":19},{"item":"1","score":18}]}}
{"query":{"user":"5"},"prediction":{"itemScores":[{"item":"1","score":24},{"item":"4","score":14}]}}
```

See the included [console usage help](https://github.com/apache/incubator-predictionio/pull/412/files#diff-2cf174557564e09d52157be8e839fecf)

Thanks to @dszeto for architectural guidance and debugging assistance.