### PR TITLE
Fix use of case class in textclassifier example

### DIFF
--- a/docs/manual/source/demo/textclassification.html.md.erb
+++ b/docs/manual/source/demo/textclassification.html.md.erb
@@ -570,7 +570,7 @@ Once you have a vector of class probabilities, you can classify the text documen
   def predict(doc : String) : PredictedResult = {
     val x: Array[Double] = getScores(doc)
     val y: (Double, Double) = (nb.labels zip x).maxBy(_._2)
-    new PredictedResult(pd.categoryMap.getOrElse(y._1, ""), y._2)
+    PredictedResult(pd.categoryMap.getOrElse(y._1, ""), y._2)
   }
 ```
 


### PR DESCRIPTION
The text-classifier example is fixed in https://github.com/apache/incubator-predictionio-template-text-classifier/pull/14.