### PR TITLE
[PIO-116] PySpark Support

### DIFF
--- a/bin/pio-shell
+++ b/bin/pio-shell
@@ -59,6 +59,15 @@ then
   . ${PIO_HOME}/bin/compute-classpath.sh
   shift
   ${SPARK_HOME}/bin/spark-shell --jars ${ASSEMBLY_JARS} $@
+elif [[ "$1" == "--with-pyspark" ]]
+then
+  echo "Starting the PIO shell with the Apache Spark Shell."
+  # Get paths of assembly jars to pass to pyspark
+  . ${PIO_HOME}/bin/compute-classpath.sh
+  shift
+  export PYTHONSTARTUP=${PIO_HOME}/python/pypio/shell.py
+  export PYTHONPATH=${PIO_HOME}/python
+  ${SPARK_HOME}/bin/pyspark --jars ${ASSEMBLY_JARS} $@
 else
   echo -e "\033[0;33mStarting the PIO shell without Apache Spark.\033[0m"
   echo -e "\033[0;33mIf you need the Apache Spark library, run 'pio-shell --with-spark [spark-submit arguments...]'.\033[0m"

--- a/data/src/main/spark-2/org/apache/predictionio/data/store/python/PPythonEventStore.scala
+++ b/data/src/main/spark-2/org/apache/predictionio/data/store/python/PPythonEventStore.scala
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.predictionio.data.store.python
+
+import java.sql.Timestamp
+
+import org.apache.predictionio.data.store.PEventStore
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.joda.time.DateTime
+
+
+/** This object provides a set of operation to access Event Store
+  * with Spark's parallelization
+  */
+object PPythonEventStore {
+
+
+  /** Read events from Event Store
+    *
+    * @param appName          return events of this app
+    * @param channelName      return events of this channel (default channel if it's None)
+    * @param startTime        return events with eventTime >= startTime
+    * @param untilTime        return events with eventTime < untilTime
+    * @param entityType       return events of this entityType
+    * @param entityId         return events of this entityId
+    * @param eventNames       return events with any of these event names.
+    * @param targetEntityType return events of this targetEntityType:
+    *   - None means no restriction on targetEntityType
+    *   - Some(None) means no targetEntityType for this event
+    *   - Some(Some(x)) means targetEntityType should match x.
+    * @param targetEntityId   return events of this targetEntityId
+    *   - None means no restriction on targetEntityId
+    *   - Some(None) means no targetEntityId for this event
+    *   - Some(Some(x)) means targetEntityId should match x.
+    * @param spark            Spark context
+    * @return DataFrame
+    */
+  def find(
+            appName: String,
+            channelName: String,
+            startTime: Timestamp,
+            untilTime: Timestamp,
+            entityType: String,
+            entityId: String,
+            eventNames: Array[String],
+            targetEntityType: String,
+            targetEntityId: String
+          )(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    val colNames: Seq[String] =
+      Seq(
+        "eventId",
+        "event",
+        "entityType",
+        "entityId",
+        "targetEntityType",
+        "targetEntityId",
+        "eventTime",
+        "tags",
+        "prId",
+        "creationTime",
+        "fields"
+      )
+    PEventStore.find(appName,
+      Option(channelName),
+      Option(startTime).map(t => new DateTime(t.getTime)),
+      Option(untilTime).map(t => new DateTime(t.getTime)),
+      Option(entityType),
+      Option(entityId),
+      Option(eventNames),
+      Option(Option(targetEntityType)),
+      Option(Option(targetEntityId)))(spark.sparkContext).map { e =>
+      (
+        e.eventId,
+        e.event,
+        e.entityType,
+        e.entityId,
+        e.targetEntityType.orNull,
+        e.targetEntityId.orNull,
+        new Timestamp(e.eventTime.getMillis),
+        e.tags.mkString("\t"),
+        e.prId.orNull,
+        new Timestamp(e.creationTime.getMillis),
+        e.properties.fields.mapValues(_.toString)
+      )
+    }.toDF(colNames: _*)
+  }
+
+  /** Aggregate properties of entities based on these special events:
+    * \$set, \$unset, \$delete events.
+    *
+    * @param appName     use events of this app
+    * @param entityType  aggregate properties of the entities of this entityType
+    * @param channelName use events of this channel (default channel if it's None)
+    * @param startTime   use events with eventTime >= startTime
+    * @param untilTime   use events with eventTime < untilTime
+    * @param required    only keep entities with these required properties defined
+    * @param spark       Spark session
+    * @return DataFrame  DataFrame of entityId and PropetyMap pair
+    */
+  def aggregateProperties(
+                           appName: String,
+                           entityType: String,
+                           channelName: String,
+                           startTime: Timestamp,
+                           untilTime: Timestamp,
+                           required: Array[String]
+                         )
+                         (spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    val colNames: Seq[String] =
+      Seq(
+        "entityId",
+        "firstUpdated",
+        "lastUpdated",
+        "fields"
+      )
+    PEventStore.aggregateProperties(appName,
+      entityType,
+      Option(channelName),
+      Option(startTime).map(t => new DateTime(t.getTime)),
+      Option(untilTime).map(t => new DateTime(t.getTime)),
+      Option(required.toSeq))(spark.sparkContext).map { x =>
+      val m = x._2
+      (x._1,
+        new Timestamp(m.firstUpdated.getMillis),
+        new Timestamp(m.lastUpdated.getMillis),
+        m.fields.mapValues(_.toString)
+      )
+    }.toDF(colNames: _*)
+  }
+}

--- a/data/src/main/spark-2/org/apache/predictionio/data/store/python/PPythonEventStore.scala
+++ b/data/src/main/spark-2/org/apache/predictionio/data/store/python/PPythonEventStore.scala
@@ -95,7 +95,7 @@ object PPythonEventStore {
         e.tags.mkString("\t"),
         e.prId.orNull,
         new Timestamp(e.creationTime.getMillis),
-        e.properties.fields.mapValues(_.toString)
+        e.properties.fields.mapValues(_.values.toString)
       )
     }.toDF(colNames: _*)
   }
@@ -139,7 +139,7 @@ object PPythonEventStore {
       (x._1,
         new Timestamp(m.firstUpdated.getMillis),
         new Timestamp(m.lastUpdated.getMillis),
-        m.fields.mapValues(_.toString)
+        m.fields.mapValues(_.values.toString)
       )
     }.toDF(colNames: _*)
   }

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -83,6 +83,7 @@ cd ${FWDIR}
 rm -rf ${DISTDIR}
 mkdir -p ${DISTDIR}/bin
 mkdir -p ${DISTDIR}/conf
+mkdir -p ${DISTDIR}/python
 mkdir -p ${DISTDIR}/lib
 mkdir -p ${DISTDIR}/lib/spark
 mkdir -p ${DISTDIR}/project
@@ -91,6 +92,7 @@ mkdir -p ${DISTDIR}/sbt
 
 cp ${FWDIR}/bin/* ${DISTDIR}/bin || :
 cp ${FWDIR}/conf/* ${DISTDIR}/conf
+cp -r ${FWDIR}/python/* ${DISTDIR}/python
 cp ${FWDIR}/project/build.properties ${DISTDIR}/project
 cp ${FWDIR}/sbt/sbt ${DISTDIR}/sbt
 cp ${FWDIR}/assembly/src/universal/lib/*assembly*jar ${DISTDIR}/lib

--- a/python/pypio/__init__.py
+++ b/python/pypio/__init__.py
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+PyPIO is the Python API for PredictionIO.
+"""

--- a/python/pypio/data/__init__.py
+++ b/python/pypio/data/__init__.py
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import
+
+from pypio.data.eventstore import PEventStore
+
+
+__all__ = [
+    'PEventStore'
+]

--- a/python/pypio/data/eventstore.py
+++ b/python/pypio/data/eventstore.py
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import
+
+from pypio.utils import new_string_array
+from pyspark.sql.dataframe import DataFrame
+
+__all__ = ["PEventStore"]
+
+
+class PEventStore(object):
+
+    def __init__(self, jss, sql_ctx):
+        self._jss = jss
+        self.sql_ctx = sql_ctx
+        self._sc = sql_ctx and sql_ctx._sc
+
+    def find(self, app_name, channel_name=None, start_time=None, until_time=None,
+             entity_type=None, entity_id=None, event_names=None, target_entity_type=None,
+             target_entity_id=None):
+        pes = self._sc._jvm.org.apache.predictionio.data.store.python.PPythonEventStore
+        jdf = pes.find(app_name, channel_name, start_time, until_time, entity_type, entity_id,
+                       event_names, target_entity_type, target_entity_id, self._jss)
+        return DataFrame(jdf, self.sql_ctx)
+
+    def aggregate_properties(self, app_name, entity_type, channel_name=None,
+                             start_time=None, until_time=None, required=None):
+        pes = self._sc._jvm.org.apache.predictionio.data.store.python.PPythonEventStore
+        jdf = pes.aggregateProperties(app_name, entity_type, channel_name,
+                                      start_time, until_time,
+                                      new_string_array(required, self._sc._gateway),
+                                      self._jss)
+        return DataFrame(jdf, self.sql_ctx)
+
+

--- a/python/pypio/shell.py
+++ b/python/pypio/shell.py
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pypio.data import PEventStore
+
+p_event_store = PEventStore(spark._jsparkSession, sqlContext)
+

--- a/python/pypio/utils.py
+++ b/python/pypio/utils.py
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def new_string_array(list_data, gateway):
+    if list_data is None:
+        return None
+    string_class = gateway.jvm.String
+    args = gateway.new_array(string_class, len(list_data))
+    for i in range(len(list_data)):
+        args[i] = list_data[i]
+    return args
+

--- a/tools/src/main/scala/org/apache/predictionio/tools/RunWorkflow.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/RunWorkflow.scala
@@ -39,6 +39,7 @@ case class WorkflowArgs(
   stopAfterRead: Boolean = false,
   stopAfterPrepare: Boolean = false,
   skipSanityCheck: Boolean = false,
+  mainPyFile: Option[String] = None,
   jsonExtractor: JsonExtractorOption = JsonExtractorOption.Both)
 
 object RunWorkflow extends Logging {
@@ -85,8 +86,12 @@ object RunWorkflow extends Logging {
       (if (wa.batch != "") Seq("--batch", wa.batch) else Seq()) ++
       Seq("--json-extractor", wa.jsonExtractor.toString)
 
+    val resourceName = wa.mainPyFile match {
+      case Some(x) => x
+      case _ => "org.apache.predictionio.workflow.CreateWorkflow"
+    }
     Runner.runOnSpark(
-      "org.apache.predictionio.workflow.CreateWorkflow",
+      resourceName,
       args,
       sa,
       jarFiles,

--- a/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
@@ -214,6 +214,9 @@ object Console extends Logging {
           opt[String]("engine-params-key") action { (x, c) =>
             c.copy(workflow = c.workflow.copy(engineParamsKey = Some(x)))
           },
+          opt[String]("main-py-file") action { (x, c) =>
+            c.copy(workflow = c.workflow.copy(mainPyFile = Some(x)))
+          },
           opt[String]("json-extractor") action { (x, c) =>
             c.copy(workflow = c.workflow.copy(jsonExtractor = JsonExtractorOption.withName(x)))
           } validate { x =>


### PR DESCRIPTION
This PR provides PySpark support with minimum PIO changes.

1. Support pyspark on pio-shell
2. Add python files to use pyspark
3. Add --main-py-file option to "pio train" to submit .py file to spark

Note that this provides only fixes for Spark 2.x.
(because this fixes expect to use SparkML)

Sample project is:
https://github.com/jpioug/predictionio-template-iris
(For prediction API, Scala code is used.)