### PR TITLE
[PIO-120] Process hangs if Elasticsearch is not available during train

### DIFF
--- a/core/src/main/scala/org/apache/predictionio/workflow/CreateWorkflow.scala
+++ b/core/src/main/scala/org/apache/predictionio/workflow/CreateWorkflow.scala
@@ -134,144 +134,148 @@ object CreateWorkflow extends Logging {
   }
 
   def main(args: Array[String]): Unit = {
-    val wfcOpt = parser.parse(args, WorkflowConfig())
-    if (wfcOpt.isEmpty) {
-      logger.error("WorkflowConfig is empty. Quitting")
-      return
-    }
-
-    val wfc = wfcOpt.get
-
-    WorkflowUtils.modifyLogging(wfc.verbose)
-
-    val evaluation = wfc.evaluationClass.map { ec =>
-      try {
-        WorkflowUtils.getEvaluation(ec, getClass.getClassLoader)._2
-      } catch {
-        case e @ (_: ClassNotFoundException | _: NoSuchMethodException) =>
-          error(s"Unable to obtain evaluation $ec. Aborting workflow.", e)
-          sys.exit(1)
+    try {
+      val wfcOpt = parser.parse(args, WorkflowConfig())
+      if (wfcOpt.isEmpty) {
+        logger.error("WorkflowConfig is empty. Quitting")
+        return
       }
-    }
 
-    val engineParamsGenerator = wfc.engineParamsGeneratorClass.map { epg =>
-      try {
-        WorkflowUtils.getEngineParamsGenerator(epg, getClass.getClassLoader)._2
-      } catch {
-        case e @ (_: ClassNotFoundException | _: NoSuchMethodException) =>
-          error(s"Unable to obtain engine parameters generator $epg. " +
-            "Aborting workflow.", e)
-          sys.exit(1)
-      }
-    }
+      val wfc = wfcOpt.get
 
-    val pioEnvVars = wfc.env.map { e =>
-      e.split(',').flatMap { p =>
-        p.split('=') match {
-          case Array(k, v) => List(k -> v)
-          case _ => Nil
+      WorkflowUtils.modifyLogging(wfc.verbose)
+
+      val evaluation = wfc.evaluationClass.map { ec =>
+        try {
+          WorkflowUtils.getEvaluation(ec, getClass.getClassLoader)._2
+        } catch {
+          case e @ (_: ClassNotFoundException | _: NoSuchMethodException) =>
+            error(s"Unable to obtain evaluation $ec. Aborting workflow.", e)
+            sys.exit(1)
         }
-      }.toMap
-    }.getOrElse(Map.empty)
+      }
 
-    if (evaluation.isEmpty) {
-      val variantJson = parse(stringFromFile(wfc.engineVariant))
-      val engineFactory = if (wfc.engineFactory == "") {
-        variantJson \ "engineFactory" match {
+      val engineParamsGenerator = wfc.engineParamsGeneratorClass.map { epg =>
+        try {
+          WorkflowUtils.getEngineParamsGenerator(epg, getClass.getClassLoader)._2
+        } catch {
+          case e @ (_: ClassNotFoundException | _: NoSuchMethodException) =>
+            error(s"Unable to obtain engine parameters generator $epg. " +
+              "Aborting workflow.", e)
+            sys.exit(1)
+        }
+      }
+
+      val pioEnvVars = wfc.env.map { e =>
+        e.split(',').flatMap { p =>
+          p.split('=') match {
+            case Array(k, v) => List(k -> v)
+            case _ => Nil
+          }
+        }.toMap
+      }.getOrElse(Map.empty)
+
+      if (evaluation.isEmpty) {
+        val variantJson = parse(stringFromFile(wfc.engineVariant))
+        val engineFactory = if (wfc.engineFactory == "") {
+          variantJson \ "engineFactory" match {
+            case JString(s) => s
+            case _ =>
+              error("Unable to read engine factory class name from " +
+                s"${wfc.engineVariant}. Aborting.")
+              sys.exit(1)
+          }
+        } else wfc.engineFactory
+        val variantId = variantJson \ "id" match {
           case JString(s) => s
           case _ =>
-            error("Unable to read engine factory class name from " +
+            error("Unable to read engine variant ID from " +
               s"${wfc.engineVariant}. Aborting.")
             sys.exit(1)
         }
-      } else wfc.engineFactory
-      val variantId = variantJson \ "id" match {
-        case JString(s) => s
-        case _ =>
-          error("Unable to read engine variant ID from " +
-            s"${wfc.engineVariant}. Aborting.")
-          sys.exit(1)
-      }
-      val (engineLanguage, engineFactoryObj) = try {
-        WorkflowUtils.getEngine(engineFactory, getClass.getClassLoader)
-      } catch {
-        case e @ (_: ClassNotFoundException | _: NoSuchMethodException) =>
-          error(s"Unable to obtain engine: ${e.getMessage}. Aborting workflow.")
-          sys.exit(1)
-      }
+        val (engineLanguage, engineFactoryObj) = try {
+          WorkflowUtils.getEngine(engineFactory, getClass.getClassLoader)
+        } catch {
+          case e @ (_: ClassNotFoundException | _: NoSuchMethodException) =>
+            error(s"Unable to obtain engine: ${e.getMessage}. Aborting workflow.")
+            sys.exit(1)
+        }
 
-      val engine: BaseEngine[_, _, _, _] = engineFactoryObj()
+        val engine: BaseEngine[_, _, _, _] = engineFactoryObj()
 
-      val customSparkConf = WorkflowUtils.extractSparkConf(variantJson)
-      val workflowParams = WorkflowParams(
-        verbose = wfc.verbosity,
-        skipSanityCheck = wfc.skipSanityCheck,
-        stopAfterRead = wfc.stopAfterRead,
-        stopAfterPrepare = wfc.stopAfterPrepare,
-        sparkEnv = WorkflowParams().sparkEnv ++ customSparkConf)
+        val customSparkConf = WorkflowUtils.extractSparkConf(variantJson)
+        val workflowParams = WorkflowParams(
+          verbose = wfc.verbosity,
+          skipSanityCheck = wfc.skipSanityCheck,
+          stopAfterRead = wfc.stopAfterRead,
+          stopAfterPrepare = wfc.stopAfterPrepare,
+          sparkEnv = WorkflowParams().sparkEnv ++ customSparkConf)
 
-      // Evaluator Not Specified. Do training.
-      if (!engine.isInstanceOf[Engine[_,_,_,_,_,_]]) {
-        throw new NoSuchMethodException(s"Engine $engine is not trainable")
-      }
+        // Evaluator Not Specified. Do training.
+        if (!engine.isInstanceOf[Engine[_,_,_,_,_,_]]) {
+          throw new NoSuchMethodException(s"Engine $engine is not trainable")
+        }
 
-      val trainableEngine = engine.asInstanceOf[Engine[_, _, _, _, _, _]]
+        val trainableEngine = engine.asInstanceOf[Engine[_, _, _, _, _, _]]
 
-      val engineParams = if (wfc.engineParamsKey == "") {
-        trainableEngine.jValueToEngineParams(variantJson, wfc.jsonExtractor)
+        val engineParams = if (wfc.engineParamsKey == "") {
+          trainableEngine.jValueToEngineParams(variantJson, wfc.jsonExtractor)
+        } else {
+          engineFactoryObj.engineParams(wfc.engineParamsKey)
+        }
+
+        val engineInstance = EngineInstance(
+          id = "",
+          status = "INIT",
+          startTime = DateTime.now,
+          endTime = DateTime.now,
+          engineId = wfc.engineId,
+          engineVersion = wfc.engineVersion,
+          engineVariant = variantId,
+          engineFactory = engineFactory,
+          batch = wfc.batch,
+          env = pioEnvVars,
+          sparkConf = workflowParams.sparkEnv,
+          dataSourceParams =
+            JsonExtractor.paramToJson(wfc.jsonExtractor, engineParams.dataSourceParams),
+          preparatorParams =
+            JsonExtractor.paramToJson(wfc.jsonExtractor, engineParams.preparatorParams),
+          algorithmsParams =
+            JsonExtractor.paramsToJson(wfc.jsonExtractor, engineParams.algorithmParamsList),
+          servingParams =
+            JsonExtractor.paramToJson(wfc.jsonExtractor, engineParams.servingParams))
+
+        val engineInstanceId = Storage.getMetaDataEngineInstances.insert(
+          engineInstance)
+
+        CoreWorkflow.runTrain(
+          env = pioEnvVars,
+          params = workflowParams,
+          engine = trainableEngine,
+          engineParams = engineParams,
+          engineInstance = engineInstance.copy(id = engineInstanceId))
       } else {
-        engineFactoryObj.engineParams(wfc.engineParamsKey)
+        val workflowParams = WorkflowParams(
+          verbose = wfc.verbosity,
+          skipSanityCheck = wfc.skipSanityCheck,
+          stopAfterRead = wfc.stopAfterRead,
+          stopAfterPrepare = wfc.stopAfterPrepare,
+          sparkEnv = WorkflowParams().sparkEnv)
+        val evaluationInstance = EvaluationInstance(
+          evaluationClass = wfc.evaluationClass.get,
+          engineParamsGeneratorClass = wfc.engineParamsGeneratorClass.get,
+          batch = wfc.batch,
+          env = pioEnvVars,
+          sparkConf = workflowParams.sparkEnv
+        )
+        Workflow.runEvaluation(
+          evaluation = evaluation.get,
+          engineParamsGenerator = engineParamsGenerator.get,
+          evaluationInstance = evaluationInstance,
+          params = workflowParams)
       }
-
-      val engineInstance = EngineInstance(
-        id = "",
-        status = "INIT",
-        startTime = DateTime.now,
-        endTime = DateTime.now,
-        engineId = wfc.engineId,
-        engineVersion = wfc.engineVersion,
-        engineVariant = variantId,
-        engineFactory = engineFactory,
-        batch = wfc.batch,
-        env = pioEnvVars,
-        sparkConf = workflowParams.sparkEnv,
-        dataSourceParams =
-          JsonExtractor.paramToJson(wfc.jsonExtractor, engineParams.dataSourceParams),
-        preparatorParams =
-          JsonExtractor.paramToJson(wfc.jsonExtractor, engineParams.preparatorParams),
-        algorithmsParams =
-          JsonExtractor.paramsToJson(wfc.jsonExtractor, engineParams.algorithmParamsList),
-        servingParams =
-          JsonExtractor.paramToJson(wfc.jsonExtractor, engineParams.servingParams))
-
-      val engineInstanceId = Storage.getMetaDataEngineInstances.insert(
-        engineInstance)
-
-      CoreWorkflow.runTrain(
-        env = pioEnvVars,
-        params = workflowParams,
-        engine = trainableEngine,
-        engineParams = engineParams,
-        engineInstance = engineInstance.copy(id = engineInstanceId))
-    } else {
-      val workflowParams = WorkflowParams(
-        verbose = wfc.verbosity,
-        skipSanityCheck = wfc.skipSanityCheck,
-        stopAfterRead = wfc.stopAfterRead,
-        stopAfterPrepare = wfc.stopAfterPrepare,
-        sparkEnv = WorkflowParams().sparkEnv)
-      val evaluationInstance = EvaluationInstance(
-        evaluationClass = wfc.evaluationClass.get,
-        engineParamsGeneratorClass = wfc.engineParamsGeneratorClass.get,
-        batch = wfc.batch,
-        env = pioEnvVars,
-        sparkConf = workflowParams.sparkEnv
-      )
-      Workflow.runEvaluation(
-        evaluation = evaluation.get,
-        engineParamsGenerator = engineParamsGenerator.get,
-        evaluationInstance = evaluationInstance,
-        params = workflowParams)
+    } finally {
+      CleanupFunctions.run()
     }
   }
 }


### PR DESCRIPTION
Fixes [PIO-120](https://issues.apache.org/jira/browse/PIO-120)

This changeset ensures that the process exits gracefully after ES connection error.

Apologies for the indentation shift. This changeset simply wraps the body of the main function with:

```scala
try {
  // much existing code
} finally {
  CleanupFunctions.run()
}
```