### PR TITLE
[PIO-129] Move CLI document

### DIFF
--- a/docs/manual/data/nav/main.yml
+++ b/docs/manual/data/nav/main.yml
@@ -59,9 +59,6 @@ root:
         body: 'Deploying as a Web Service'
         url: '/deploy/'
       -
-        body: 'Engine Command-line Interface'
-        url: '/cli/#engine-commands'
-      -
         body: 'Batch Predictions'
         url: '/batchpredict/'
       -
@@ -96,9 +93,6 @@ root:
       -
         body: 'Event Server Overview'
         url: '/datacollection/'
-      -
-        body: 'Event Server Command-line Interface'
-        url: '/cli/#event-server-commands'
       -
         body: 'Collecting Data with REST/SDKs'
         url: '/datacollection/eventapi/'
@@ -321,6 +315,9 @@ root:
     body: 'Resources'
     url: '#'
     children:
+      -
+        body: 'Command-line Interface'
+        url: '/cli/'
       -
         body: 'Release Cadence'
         url: '/resources/release/'

--- a/docs/manual/source/datacollection/eventapi.html.md
+++ b/docs/manual/source/datacollection/eventapi.html.md
@@ -428,3 +428,5 @@ Please use the following CLI command:
 ```
 $ pio app data-delete <your_app_name>
 ```
+
+INFO: See [here](/cli/#event-server-commands) to know details of command-line interface for the event server.

--- a/docs/manual/source/deploy/index.html.md
+++ b/docs/manual/source/deploy/index.html.md
@@ -31,8 +31,10 @@ After you have [downloaded an Engine Template](/start/download/),  you can deplo
 
 1. Run `pio app new **your-app-name-here**` and specify the `appName` used in the template's *engine.json* file (you can set it there to your preference).
 2. Run `pio build` to update the engine
-2. Run `pio train` to train a predictive model with training data
-3. Run `pio deploy` to deploy the engine as a service
+3. Run `pio train` to train a predictive model with training data
+4. Run `pio deploy` to deploy the engine as a service
+
+INFO: See [here](/cli/#engine-commands) to know details of command-line interface for the engine server.
 
 A deployed engine listens to port 8000 by default. Your application can [send query to retrieve prediction](/appintegration/) in real-time through the REST interface.
 


### PR DESCRIPTION
There are links to CLI document in the deploy section and collecting data section of the side menu, but if these links are clicked, the side menu is closed because these links have a hash like `/cli/#engine-commands`. I think that such unclear navigation would confuse readers.
https://predictionio.incubator.apache.org/cli/#engine-commands

I propose to remove these links from the deploy section and the collecting data section, and put a link to CLI document in the resource section without hash:

![cli-doc1](https://user-images.githubusercontent.com/1094760/31218456-5e1e312e-a9f5-11e7-8d8f-e4d1e06e3d08.png)

In addition, put links to the CLI reference in documents of the event server and the engine server. A following screenshot shows a link to the event server CLI in the document about deployment:

![cli-doc2](https://user-images.githubusercontent.com/1094760/31218708-248da2c2-a9f6-11e7-8a8a-6bef8ee1e6e5.png)


