### PR TITLE
Fix batchpredict for custom PersistentModel

### DIFF
--- a/tools/src/main/scala/org/apache/predictionio/tools/RunBatchPredict.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/RunBatchPredict.scala
@@ -31,7 +31,6 @@ import scala.sys.process._
 case class BatchPredictArgs(
   inputFilePath: String = "batchpredict-input.json",
   outputFilePath: String = "batchpredict-output.json",
-  queryPartitions: Option[Int] = None,
   variantJson: Option[File] = None,
   jsonExtractor: JsonExtractorOption = JsonExtractorOption.Both)
 
@@ -59,9 +58,6 @@ object RunBatchPredict extends Logging {
       "--engine-variant",
       batchPredictArgs.variantJson.getOrElse(
         new File(engineDirPath, "engine.json")).getCanonicalPath) ++
-      (if (batchPredictArgs.queryPartitions.isEmpty) Nil
-        else Seq("--query-partitions",
-                  batchPredictArgs.queryPartitions.get.toString)) ++
       (if (verbose) Seq("--verbose") else Nil) ++
       Seq("--json-extractor", batchPredictArgs.jsonExtractor.toString)
 

--- a/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
+++ b/tools/src/main/scala/org/apache/predictionio/tools/console/Console.scala
@@ -331,28 +331,20 @@ object Console extends Logging {
       cmd("batchpredict").
         text("Use an engine instance to process batch predictions. This\n" +
               "command will pass all pass-through arguments to its underlying\n" +
-              "spark-submit command. All algorithm classes used in the engine\n" +
-              "must be serializable.").
+              "spark-submit command.").
         action { (_, c) =>
           c.copy(commands = c.commands :+ "batchpredict")
         } children(
           opt[String]("input") action { (x, c) =>
             c.copy(batchPredict = c.batchPredict.copy(inputFilePath = x))
           } text("Path to file containing queries; a multi-object JSON file\n" +
-                  "with one query object per line. Accepts any valid Hadoop\n" +
-                  "file URL. Default: batchpredict-input.json"),
+                  "with one query object per line.\n" +
+                  "Default: batchpredict-input.json"),
           opt[String]("output") action { (x, c) =>
             c.copy(batchPredict = c.batchPredict.copy(outputFilePath = x))
           } text("Path to file to receive results; a multi-object JSON file\n" +
                   "with one object per line, the prediction + original query.\n" +
-                  "Accepts any valid Hadoop file URL. Actual output will be\n" +
-                  "written as Hadoop partition files in a directory with the\n" +
-                  "output name. Default: batchpredict-output.json"),
-          opt[Int]("query-partitions") action { (x, c) =>
-            c.copy(batchPredict = c.batchPredict.copy(queryPartitions = Some(x)))
-          } text("Limit concurrency of predictions by setting the number\n" +
-                  "of partitions used internally for the RDD of queries.\n" +
-                  "Default: number created by Spark context's `textFile`"),
+                  "Default: batchpredict-output.json"),
           opt[String]("engine-instance-id") action { (x, c) =>
             c.copy(engineInstanceId = Some(x))
           } text("Engine instance ID."),
@@ -696,7 +688,6 @@ object Console extends Logging {
             BatchPredictArgs(
               ca.batchPredict.inputFilePath,
               ca.batchPredict.outputFilePath,
-              ca.batchPredict.queryPartitions,
               ca.workflow.variantJson,
               ca.workflow.jsonExtractor),
             ca.spark,


### PR DESCRIPTION
Fixes [PIO-138](https://issues.apache.org/jira/browse/PIO-138)

Switches batch query processing from Spark RDD to a Scala parallel collection. As a result, the `pio batchpredict` command changes in the following ways:

* `--query-partitions` option is no longer available; parallelism is now managed by Scala's [parallel collections](http://docs.scala-lang.org/overviews/parallel-collections/overview.html)
* `--input` option is now read as a plain, local file
* `--output` option is now written as a plain, local file
* because the input & output files are no longer parallelized through Spark, memory limits may require that large batch jobs be split into multiple command runs.

This solves the root problem that certain custom PersistentModels, such as [ALS Recommendation template](https://github.com/apache/incubator-predictionio-template-recommender), may themselves [contain RDDs](https://github.com/apache/incubator-predictionio-template-recommender/blob/develop/src/main/scala/ALSModel.scala#L27), which cannot be nested inside the batch queries RDD. (See [SPARK-5063](https://issues.apache.org/jira/browse/SPARK-5063))